### PR TITLE
Implement core event module

### DIFF
--- a/siddhi_rust/src/core/event/README.md
+++ b/siddhi_rust/src/core/event/README.md
@@ -1,0 +1,34 @@
+# Event Module (`core::event`)
+
+This directory contains the Rust translation of the Java
+`io.siddhi.core.event` package.  The structures mirror the original
+implementation as closely as possible while adopting idiomatic Rust
+where appropriate.
+
+## Highlights
+
+- `value.rs` provides `AttributeValue` representing the different types
+  that can be carried inside an event.
+- `event.rs`, `stream_event.rs` and `state_event.rs` implement the core
+  event types used by Siddhi.  Methods such as `copy_from_complex`,
+  attribute access via Siddhi position arrays and event chain
+  manipulation are supported.
+- `complex_event.rs` defines the `ComplexEvent` trait and the
+  `ComplexEventType` enum.
+- `meta_state_event.rs` and `meta_stream_event.rs` hold meta information
+  describing the structure of state and stream events.
+- Constants used for array index calculations are located in
+  `core::util::siddhi_constants.rs`.
+
+## TODO
+
+The current implementation is functional enough for simple query
+execution but several areas still need work:
+
+- Comprehensive cloning of event chains.
+- Full parity with all methods of the Java classes (some advanced
+  serialization helpers are omitted).
+- Additional utility types under `state` and `stream` packages are not
+  yet ported.
+
+Contributions and further improvements are welcome.

--- a/siddhi_rust/src/core/event/state/meta_state_event.rs
+++ b/siddhi_rust/src/core/event/state/meta_state_event.rs
@@ -37,10 +37,46 @@ impl MetaStateEvent {
         }
     }
 
-    // TODO: Implement methods from MetaStateEvent.java
-    // get_meta_stream_event(position)
-    // add_event(MetaStreamEvent)
-    // add_output_data_allowing_duplicate(MetaStateEventAttribute)
-    // set_output_definition(StreamDefinition)
-    // clone()
+    pub fn get_meta_stream_event(&self, position: usize) -> Option<&MetaStreamEvent> {
+        self.meta_stream_events.get(position)?.as_ref()
+    }
+
+    pub fn get_meta_stream_event_mut(&mut self, position: usize) -> Option<&mut MetaStreamEvent> {
+        self.meta_stream_events.get_mut(position)?.as_mut()
+    }
+
+    pub fn add_event(&mut self, meta_stream_event: MetaStreamEvent) {
+        self.meta_stream_events.push(Some(meta_stream_event));
+    }
+
+    pub fn add_output_data_allowing_duplicate(&mut self, attr: QueryApiAttribute) {
+        match &mut self.output_data_attributes {
+            Some(vec) => vec.push(attr),
+            None => self.output_data_attributes = Some(vec![attr]),
+        }
+    }
+
+    pub fn set_output_definition(&mut self, def: StreamDefinition) {
+        self.output_stream_definition = Some(Arc::new(def));
+    }
+
+    pub fn get_output_data_attributes(&self) -> &[QueryApiAttribute] {
+        self.output_data_attributes.as_deref().unwrap_or(&[])
+    }
+
+    pub fn stream_event_count(&self) -> usize {
+        self.meta_stream_events.len()
+    }
+
+    pub fn clone_meta_state_event(&self) -> Self {
+        let mut clone = MetaStateEvent {
+            meta_stream_events: Vec::with_capacity(self.meta_stream_events.len()),
+            output_stream_definition: self.output_stream_definition.clone(),
+            output_data_attributes: self.output_data_attributes.clone(),
+        };
+        for opt in &self.meta_stream_events {
+            clone.meta_stream_events.push(opt.clone());
+        }
+        clone
+    }
 }

--- a/siddhi_rust/src/core/util/siddhi_constants.rs
+++ b/siddhi_rust/src/core/util/siddhi_constants.rs
@@ -1,14 +1,35 @@
 // siddhi_rust/src/core/util/siddhi_constants.rs
 
-// Placeholder for core-specific constants.
-// If these are meant to be the same as query_api/constants.rs,
-// this module could re-export them.
+//! Constants used inside the Siddhi core implementation.  These mirror the
+//! values found in the Java `io.siddhi.core.util.SiddhiConstants` class that are
+//! required by the currently ported modules.  Only the subset needed by the Rust
+//! code base is included here.
+
+// Position indexes for attribute arrays used by `StreamEvent`/`StateEvent`.
+pub const BEFORE_WINDOW_DATA_INDEX: usize = 0;
+pub const ON_AFTER_WINDOW_DATA_INDEX: usize = 1;
+pub const OUTPUT_DATA_INDEX: usize = 2;
+pub const STATE_OUTPUT_DATA_INDEX: usize = 3;
+
+pub const STREAM_EVENT_CHAIN_INDEX: usize = 0;
+pub const STREAM_EVENT_INDEX_IN_CHAIN: usize = 1;
+pub const STREAM_ATTRIBUTE_TYPE_INDEX: usize = 2;
+pub const STREAM_ATTRIBUTE_INDEX_IN_TYPE: usize = 3;
+
+// Misc index values used by `StateEvent` when navigating chains
+pub const CURRENT: i32 = -1;
+pub const LAST: i32 = -2;
+pub const ANY: i32 = -1;
+pub const UNKNOWN_STATE: i32 = -1;
+
+// When additional constants become necessary they should be added here to keep
+// the mapping with the Java implementation explicit.
+
+// Re‑export the query API constants so users of `core` only need one import.
+pub use crate::query_api::constants::*;
+
+/// Empty struct kept for backwards compatibility with earlier code that
+/// expected a type named `SiddhiConstants` in this module.  New code should
+/// directly use the constants above.
 pub struct SiddhiConstants;
 
-// Example if re-exporting from query_api:
-// pub use crate::query_api::constants::*;
-// And then SiddhiAppParser would use:
-// use crate::core::util::XYZ_CONSTANT; // directly
-// Or if it needs a struct to group them:
-// pub struct CoreSiddhiConstants { ... }
-// For now, an empty struct to satisfy the import.


### PR DESCRIPTION
## Summary
- finish Rust port of core event modules
- implement constants used for event indexing
- add complex event copying and display
- expand StreamEvent and StateEvent helpers
- provide meta-state event utilities
- add documentation for event module

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6840469245208325bbb10ffa485edaaf