### PR TITLE
Refine QueryRuntime and docs

### DIFF
--- a/siddhi_rust/src/core/query/README.md
+++ b/siddhi_rust/src/core/query/README.md
@@ -1,0 +1,26 @@
+# Query Module
+
+This module contains the Rust translation of Siddhi's core `query` package.  It implements
+runtime structures that execute a single Siddhi query as well as the processors that
+form the internal processing chain.
+
+## Key Components
+
+* `QueryRuntime` – lightweight representation of a query at runtime.  Holds the query
+  name, optional API model and the head of the processor chain.  It implements the
+  `QueryRuntimeTrait` which mirrors the minimal Java `QueryRuntime` interface.
+* `processor` – currently includes `FilterProcessor` as an example stream processor.
+* `selector` – provides `SelectProcessor` and `OutputAttributeProcessor` for handling
+  `select` clauses.
+* `output` – contains terminal processors such as `InsertIntoStreamProcessor` and
+  `CallbackProcessor` that publish results.
+
+## Notes / TODO
+
+* Many advanced Siddhi features like windows, joins and rate limiting are not yet
+  ported.  Placeholders are left where appropriate.
+* `QueryRuntime` does not implement snapshotting or state management.  These should
+  be added when the relevant subsystems are available.
+* Event chunk manipulation in `FilterProcessor` and `SelectProcessor` is simplified
+  and should be revisited for efficiency.
+

--- a/siddhi_rust/src/core/util/parser/query_parser.rs
+++ b/siddhi_rust/src/core/util/parser/query_parser.rs
@@ -174,7 +174,11 @@ impl QueryParser {
         }
 
         // 7. Create QueryRuntime
-        let mut query_runtime = QueryRuntime::new(query_name.clone() /*, siddhi_query_context */);
+        let mut query_runtime = QueryRuntime::new_with_context(
+            query_name.clone(),
+            Arc::new(api_query.clone()),
+            Arc::clone(&siddhi_query_context),
+        );
         query_runtime.processor_chain_head = processor_chain_head;
 
         // 8. Register the entry processor with the input stream junction

--- a/siddhi_rust/src/core/util/parser/siddhi_app_parser.rs
+++ b/siddhi_rust/src/core/util/parser/siddhi_app_parser.rs
@@ -40,7 +40,12 @@ mod query_parser_placeholder {
             let _input_junction = _stream_junction_map.get(&input_stream_id)
                 .ok_or_else(|| format!("Input stream '{}' not found for query '{}'", input_stream_id, query_name))?.clone();
 
-            Ok(QueryRuntime::new(query_name))
+            let query_ctx = Arc::new(SiddhiQueryContext::new(
+                Arc::clone(_siddhi_app_context),
+                query_name.clone(),
+                None,
+            ));
+            Ok(QueryRuntime::new_with_context(query_name, Arc::new(_api_query.clone()), query_ctx))
         }
     }
     // Placeholder getters on query_api::Query


### PR DESCRIPTION
## Summary
- expand `QueryRuntime` to store API query information and query context
- expose a `QueryRuntimeTrait` in the core query module
- adjust parsers to build the new runtime structure
- document the query module

## Testing
- `cargo check --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6840574a87608325b5f3a51cd8599d02