### PR TITLE
Finalize core event flow

### DIFF
--- a/siddhi_rust/src/core/README.md
+++ b/siddhi_rust/src/core/README.md
@@ -1,0 +1,23 @@
+# Siddhi Core (Rust Port)
+
+This directory mirrors the `io.siddhi.core` package from the Java
+implementation.  Only a minimal subset of the original runtime is
+implemented.  The goal of the current port is to support a very simple
+stateless query pipeline so the integration test in `src/lib.rs`
+(`test_simple_filter_projection_query`) executes end-to-end.
+
+## Notes
+
+* `stream_junction::send_event` now converts incoming `Event` objects
+  into `StreamEvent`s with the incoming data placed in the
+  `before_window_data` array.  This allows `FilterProcessor` and
+  `SelectProcessor` to access attributes correctly.
+* Large parts of the original Siddhi runtime remain unimplemented
+  (windows, tables, persistence, etc.).  Placeholders are provided where
+  required by the API.
+
+## TODO
+
+* Implement proper `StreamEvent` factories and event pooling.
+* Flesh out the asynchronous path in `StreamJunction`.
+* Complete support for stateful processors and other execution types.


### PR DESCRIPTION
## Summary
- propagate input event data through StreamJunction by populating `before_window_data`
- document current state of the core runtime in `src/core/README.md`

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68405a4e08ac8325ac82bc7cab57ac06