### PR TITLE
Complete executor package

### DIFF
--- a/siddhi_rust/src/core/event/stream/stream_event.rs
+++ b/siddhi_rust/src/core/event/stream/stream_event.rs
@@ -129,6 +129,21 @@ impl StreamEvent {
     pub fn has_next(&self) -> bool {
         self.next.is_some()
     }
+
+    /// Create a shallow clone of this `StreamEvent` without cloning the `next`
+    /// pointer.  This mirrors the behavior of `EventVariableFunctionExecutor`
+    /// in the Java implementation which extracts a single `StreamEvent` from a
+    /// `StateEvent` without its chain.
+    pub fn clone_without_next(&self) -> Self {
+        StreamEvent {
+            timestamp: self.timestamp,
+            output_data: self.output_data.clone(),
+            event_type: self.event_type,
+            before_window_data: self.before_window_data.clone(),
+            on_after_window_data: self.on_after_window_data.clone(),
+            next: None,
+        }
+    }
 }
 
 impl ComplexEvent for StreamEvent {

--- a/siddhi_rust/src/core/executor/README.md
+++ b/siddhi_rust/src/core/executor/README.md
@@ -1,0 +1,23 @@
+# Executor Module
+
+This directory contains Rust implementations of Siddhi's `executor` package.  The
+code mirrors the Java classes where practical.  Some functionality has been
+simplified to keep the initial port manageable.
+
+## Newly Added
+
+* **EventVariableFunctionExecutor** – retrieves a `StreamEvent` from a
+  `StateEvent` and returns it as an OBJECT value.  The returned event is a
+  shallow clone without the `next` link.
+* **MultiValueVariableFunctionExecutor** – collects attribute values from all
+  events in a `StateEvent` chain and returns them as a vector wrapped in an
+  OBJECT value.
+* Added `clone_without_next` helper on `StreamEvent` used by the new executors.
+
+## TODO
+
+* Support for the remaining Java executors such as the incremental aggregation
+  functions is still missing.
+* `EventVariableFunctionExecutor` and `MultiValueVariableFunctionExecutor`
+  assume simplified position handling compared to the Java implementation.
+  They should be revisited once the full event model is available.

--- a/siddhi_rust/src/core/executor/event_variable_function_executor.rs
+++ b/siddhi_rust/src/core/executor/event_variable_function_executor.rs
@@ -1,0 +1,53 @@
+use crate::core::executor::expression_executor::ExpressionExecutor;
+use crate::core::event::complex_event::ComplexEvent;
+use crate::core::event::state::state_event::StateEvent;
+use crate::core::event::stream::stream_event::StreamEvent;
+use crate::core::event::value::AttributeValue;
+use crate::query_api::definition::attribute::Type as ApiAttributeType;
+use std::sync::Arc;
+use crate::core::config::siddhi_app_context::SiddhiAppContext;
+use crate::core::util::siddhi_constants::{STREAM_EVENT_CHAIN_INDEX, STREAM_EVENT_INDEX_IN_CHAIN};
+
+#[derive(Debug, Clone)]
+pub struct EventVariableFunctionExecutor {
+    position: [i32; 2],
+}
+
+impl EventVariableFunctionExecutor {
+    pub fn new(stream_event_chain_index: i32, stream_event_index_in_chain: i32) -> Self {
+        Self {
+            position: [stream_event_chain_index, stream_event_index_in_chain],
+        }
+    }
+}
+
+impl ExpressionExecutor for EventVariableFunctionExecutor {
+    fn execute(&self, event_opt: Option<&dyn ComplexEvent>) -> Option<AttributeValue> {
+        let complex_event = event_opt?;
+        let state_event = complex_event.as_any().downcast_ref::<StateEvent>()?;
+        let chain_idx = self.position[STREAM_EVENT_CHAIN_INDEX] as usize;
+        let mut current = state_event.stream_events.get(chain_idx)?.as_ref()?;
+        let mut idx = 0usize;
+        while idx < self.position[STREAM_EVENT_INDEX_IN_CHAIN] as usize {
+            let next_ce = match current.next.as_deref() {
+                Some(n) => n,
+                None => return Some(AttributeValue::Null),
+            };
+            current = match next_ce.as_any().downcast_ref::<StreamEvent>() {
+                Some(se) => se,
+                None => return Some(AttributeValue::Null),
+            };
+            idx += 1;
+        }
+        let cloned = current.clone_without_next();
+        Some(AttributeValue::Object(Some(Box::new(cloned))))
+    }
+
+    fn get_return_type(&self) -> ApiAttributeType {
+        ApiAttributeType::OBJECT
+    }
+
+    fn clone_executor(&self, _ctx: &Arc<SiddhiAppContext>) -> Box<dyn ExpressionExecutor> {
+        Box::new(self.clone())
+    }
+}

--- a/siddhi_rust/src/core/executor/mod.rs
+++ b/siddhi_rust/src/core/executor/mod.rs
@@ -4,6 +4,8 @@ pub mod variable_expression_executor;
 pub mod condition;
 pub mod math;
 pub mod function;  // Added for function executors
+pub mod event_variable_function_executor;
+pub mod multi_value_variable_function_executor;
 // pub mod incremental; // For incremental aggregation executors
 
 pub use self::expression_executor::ExpressionExecutor;
@@ -12,6 +14,8 @@ pub use self::variable_expression_executor::VariableExpressionExecutor; // Remov
 pub use self::condition::*;
 pub use self::math::*;
 pub use self::function::*; // Re-export function executors
+pub use self::event_variable_function_executor::EventVariableFunctionExecutor;
+pub use self::multi_value_variable_function_executor::MultiValueVariableFunctionExecutor;
 // AttributeDynamicResolveType was in the prompt for VariableExpressionExecutor, but not used in my simplified impl yet.
 // If it were, it would be exported:
 // pub use self::variable_expression_executor::AttributeDynamicResolveType;

--- a/siddhi_rust/src/core/executor/multi_value_variable_function_executor.rs
+++ b/siddhi_rust/src/core/executor/multi_value_variable_function_executor.rs
@@ -1,0 +1,49 @@
+use crate::core::executor::expression_executor::ExpressionExecutor;
+use crate::core::event::complex_event::ComplexEvent;
+use crate::core::event::state::state_event::StateEvent;
+use crate::core::event::stream::stream_event::StreamEvent;
+use crate::core::event::value::AttributeValue;
+use crate::query_api::definition::attribute::Type as ApiAttributeType;
+use std::sync::Arc;
+use crate::core::config::siddhi_app_context::SiddhiAppContext;
+use crate::core::util::siddhi_constants::{STREAM_EVENT_CHAIN_INDEX, STREAM_ATTRIBUTE_INDEX_IN_TYPE, STREAM_ATTRIBUTE_TYPE_INDEX};
+
+#[derive(Debug, Clone)]
+pub struct MultiValueVariableFunctionExecutor {
+    chain_index: i32,
+    // Position array information for attribute retrieval
+    attribute_position: [i32; 2],
+}
+
+impl MultiValueVariableFunctionExecutor {
+    pub fn new(chain_index: i32, attribute_position: [i32; 2]) -> Self {
+        Self { chain_index, attribute_position }
+    }
+}
+
+impl ExpressionExecutor for MultiValueVariableFunctionExecutor {
+    fn execute(&self, event_opt: Option<&dyn ComplexEvent>) -> Option<AttributeValue> {
+        let complex_event = event_opt?;
+        let state_event = complex_event.as_any().downcast_ref::<StateEvent>()?;
+        let mut results: Vec<AttributeValue> = Vec::new();
+        let mut stream_event_opt = state_event.stream_events.get(self.chain_index as usize)?.as_ref();
+        while let Some(stream_event) = stream_event_opt {
+            if let Some(val) = stream_event.get_attribute_by_position(&self.attribute_position) {
+                results.push(val.clone());
+            } else {
+                results.push(AttributeValue::Null);
+            }
+            stream_event_opt = match stream_event.next.as_deref() {
+                Some(n) => n.as_any().downcast_ref::<StreamEvent>(),
+                None => None,
+            };
+        }
+        Some(AttributeValue::Object(Some(Box::new(results))))
+    }
+
+    fn get_return_type(&self) -> ApiAttributeType { ApiAttributeType::OBJECT }
+
+    fn clone_executor(&self, _ctx: &Arc<SiddhiAppContext>) -> Box<dyn ExpressionExecutor> {
+        Box::new(self.clone())
+    }
+}


### PR DESCRIPTION
## Summary
- port missing executors EventVariableFunctionExecutor and MultiValueVariableFunctionExecutor
- expose the new executors
- add `clone_without_next` helper on StreamEvent
- document executor module in README

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6841a00a41d08325b257c768d56988fe