### PR TITLE
Expand Siddhi event modules

### DIFF
--- a/siddhi_rust/src/core/event/README.md
+++ b/siddhi_rust/src/core/event/README.md
@@ -28,7 +28,8 @@ execution but several areas still need work:
 - Comprehensive cloning of event chains.
 - Full parity with all methods of the Java classes (some advanced
   serialization helpers are omitted).
-- Additional utility types under `state` and `stream` packages are not
-  yet ported.
+- Additional utility types under `state` and `stream` packages are only
+  partially ported.  Basic factories and attribute mapping structures are
+  available but cloners and populaters are TODO.
 
 Contributions and further improvements are welcome.

--- a/siddhi_rust/src/core/event/state/README.md
+++ b/siddhi_rust/src/core/event/state/README.md
@@ -1,0 +1,22 @@
+# State Event Module (`core::event::state`)
+
+Rust translation of Siddhi's `io.siddhi.core.event.state` package.  Only the
+portion required for the current prototype is implemented.
+
+## Implemented Components
+
+- `StateEvent` – internal event type used for joins and patterns.  Supports
+  attribute access via Siddhi's position arrays and linked list chaining.
+- `MetaStateEvent` – holds the meta information about a `StateEvent` such as the
+  underlying `MetaStreamEvent`s and output mappings.
+- `MetaStateEventAttribute` – mapping of a single output attribute to its
+  position within a `StateEvent`.
+- `StateEventFactory` – helper for constructing `StateEvent` instances based on
+  meta information.
+
+## Missing Parts / TODO
+
+The original Java package contains additional helpers such as
+`StateEventCloner` and a set of *populator* utilities used by the pattern and
+partition runtime.  These have not yet been ported.  A future milestone should
+add them when those engine features are implemented.

--- a/siddhi_rust/src/core/event/state/meta_state_event.rs
+++ b/siddhi_rust/src/core/event/state/meta_state_event.rs
@@ -6,7 +6,7 @@ use std::sync::Arc; // If definitions are shared
 
 // MetaStateEventAttribute is an inner class in Java, not read yet.
 // For now, assuming output data attributes can be represented by query_api::Attribute
-use crate::query_api::definition::Attribute as QueryApiAttribute;
+use crate::core::event::state::MetaStateEventAttribute;
 
 
 #[derive(Debug, Clone, Default)]
@@ -17,11 +17,9 @@ pub struct MetaStateEvent {
 
     pub output_stream_definition: Option<Arc<StreamDefinition>>,
 
-    // In Java, outputDataAttributes is List<MetaStateEventAttribute>.
-    // MetaStateEventAttribute seems to just wrap a (streamId, Attribute) pair,
-    // indicating which input stream's attribute is part of the output.
-    // For simplicity, using query_api::Attribute directly as a placeholder.
-    pub output_data_attributes: Option<Vec<QueryApiAttribute>>,
+    // In Java, outputDataAttributes is `List<MetaStateEventAttribute>`.
+    // The Rust port mirrors this structure.
+    pub output_data_attributes: Option<Vec<MetaStateEventAttribute>>,
 }
 
 impl MetaStateEvent {
@@ -49,7 +47,7 @@ impl MetaStateEvent {
         self.meta_stream_events.push(Some(meta_stream_event));
     }
 
-    pub fn add_output_data_allowing_duplicate(&mut self, attr: QueryApiAttribute) {
+    pub fn add_output_data_allowing_duplicate(&mut self, attr: MetaStateEventAttribute) {
         match &mut self.output_data_attributes {
             Some(vec) => vec.push(attr),
             None => self.output_data_attributes = Some(vec![attr]),
@@ -60,7 +58,7 @@ impl MetaStateEvent {
         self.output_stream_definition = Some(Arc::new(def));
     }
 
-    pub fn get_output_data_attributes(&self) -> &[QueryApiAttribute] {
+    pub fn get_output_data_attributes(&self) -> &[MetaStateEventAttribute] {
         self.output_data_attributes.as_deref().unwrap_or(&[])
     }
 

--- a/siddhi_rust/src/core/event/state/meta_state_event_attribute.rs
+++ b/siddhi_rust/src/core/event/state/meta_state_event_attribute.rs
@@ -1,0 +1,24 @@
+// siddhi_rust/src/core/event/state/meta_state_event_attribute.rs
+// Corresponds to io.siddhi.core.event.state.MetaStateEventAttribute
+use crate::query_api::definition::attribute::Attribute as QueryApiAttribute;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct MetaStateEventAttribute {
+    pub attribute: QueryApiAttribute,
+    pub position: Vec<i32>,
+}
+
+impl MetaStateEventAttribute {
+    pub fn new(attribute: QueryApiAttribute, position: Vec<i32>) -> Self {
+        Self { attribute, position }
+    }
+
+    pub fn get_attribute(&self) -> &QueryApiAttribute {
+        &self.attribute
+    }
+
+    pub fn get_position(&self) -> &[i32] {
+        &self.position
+    }
+}
+

--- a/siddhi_rust/src/core/event/state/mod.rs
+++ b/siddhi_rust/src/core/event/state/mod.rs
@@ -2,11 +2,12 @@
 
 pub mod state_event;
 pub mod meta_state_event;
-// pub mod state_event_factory;
-// pub mod meta_state_event_attribute; // MetaStateEventAttribute.java
+pub mod state_event_factory;
+pub mod meta_state_event_attribute; // MetaStateEventAttribute.java
 // pub mod state_event_cloner;
 // pub mod populater; // for sub-package
 
 pub use self::state_event::StateEvent;
 pub use self::meta_state_event::MetaStateEvent;
-// pub use self::meta_state_event_attribute::MetaStateEventAttribute;
+pub use self::state_event_factory::StateEventFactory;
+pub use self::meta_state_event_attribute::MetaStateEventAttribute;

--- a/siddhi_rust/src/core/event/state/state_event_factory.rs
+++ b/siddhi_rust/src/core/event/state/state_event_factory.rs
@@ -1,0 +1,28 @@
+// siddhi_rust/src/core/event/state/state_event_factory.rs
+// Corresponds to io.siddhi.core.event.state.StateEventFactory
+use super::state_event::StateEvent;
+use super::meta_state_event::MetaStateEvent;
+
+#[derive(Debug, Clone)]
+pub struct StateEventFactory {
+    pub event_size: usize,
+    pub output_data_size: usize,
+}
+
+impl StateEventFactory {
+    pub fn new(event_size: usize, output_data_size: usize) -> Self {
+        Self { event_size, output_data_size }
+    }
+
+    pub fn new_from_meta(meta: &MetaStateEvent) -> Self {
+        Self {
+            event_size: meta.stream_event_count(),
+            output_data_size: meta.get_output_data_attributes().len(),
+        }
+    }
+
+    pub fn new_instance(&self) -> StateEvent {
+        StateEvent::new(self.event_size, self.output_data_size)
+    }
+}
+

--- a/siddhi_rust/src/core/event/stream/README.md
+++ b/siddhi_rust/src/core/event/stream/README.md
@@ -1,0 +1,19 @@
+# Stream Event Module (`core::event::stream`)
+
+Rust equivalent of the Java `io.siddhi.core.event.stream` package.
+
+## Implemented Components
+
+- `StreamEvent` – main internal event representation used during stream
+  processing.
+- `MetaStreamEvent` – describes the structure of `StreamEvent` instances,
+  including before/after window data and output data.
+- `StreamEventFactory` – convenience for creating `StreamEvent` objects based on
+  meta information.
+- `Operation` – small helper struct mirroring Siddhi's `Operation` class.
+
+## Missing Parts / TODO
+
+Several advanced helpers (`StreamEventCloner`, converters, holders and
+populators) have not yet been ported.  Serialization helpers present in the Java
+implementation are also omitted for now.

--- a/siddhi_rust/src/core/event/stream/meta_stream_event.rs
+++ b/siddhi_rust/src/core/event/stream/meta_stream_event.rs
@@ -29,15 +29,14 @@ pub struct MetaStreamEvent {
     // This assumes that the 'data' array in a core::Event or core::StreamEvent
     // directly corresponds to the attributes in this input_stream_definition.
     attribute_info: HashMap<String, (usize, ApiAttributeType)>, // Use ApiAttributeType
-
-    // Other fields from Java MetaStreamEvent, commented out for this simplified version:
-    // pub on_after_window_data_attrs: Option<Vec<ApiAttribute>>,
-    // pub output_data_attrs: Option<Vec<ApiAttribute>>,
-    // pub input_definitions: Vec<Arc<ApiStreamDefinition>>, // Java uses AbstractDefinition
-    // pub input_reference_id: Option<String>,
-    // pub output_stream_definition: Option<Arc<ApiStreamDefinition>>,
+    pub before_window_data: Vec<ApiAttribute>,
+    pub on_after_window_data: Vec<ApiAttribute>,
+    pub output_data: Vec<ApiAttribute>,
+    pub input_definitions: Vec<Arc<ApiStreamDefinition>>,
+    pub input_reference_id: Option<String>,
+    pub output_stream_definition: Option<Arc<ApiStreamDefinition>>,
     pub event_type: MetaStreamEventType, // From Java
-    // pub is_multi_value: bool,
+    pub multi_value: bool,
 }
 
 impl MetaStreamEvent {
@@ -50,10 +49,16 @@ impl MetaStreamEvent {
             attribute_info.insert(api_attr.name.clone(), (index, api_attr.attribute_type.clone()));
         }
         Self {
-            input_stream_definition: input_stream_def,
+            input_stream_definition: input_stream_def.clone(),
             attribute_info,
-            event_type: MetaStreamEventType::default(), // Default type
-            // Initialize other fields if they were present
+            before_window_data: Vec::new(),
+            on_after_window_data: Vec::new(),
+            output_data: input_stream_def.abstract_definition.attribute_list.clone(),
+            input_definitions: vec![input_stream_def],
+            input_reference_id: None,
+            output_stream_definition: None,
+            event_type: MetaStreamEventType::default(),
+            multi_value: false,
         }
     }
 
@@ -61,6 +66,49 @@ impl MetaStreamEvent {
     // Returns (index_in_data_array, attribute_type)
     pub fn find_attribute_info(&self, attribute_name: &str) -> Option<&(usize, ApiAttributeType)> { // Use ApiAttributeType
         self.attribute_info.get(attribute_name)
+    }
+
+    pub fn get_before_window_data(&self) -> &[ApiAttribute] {
+        &self.before_window_data
+    }
+
+    pub fn get_on_after_window_data(&self) -> &[ApiAttribute] {
+        &self.on_after_window_data
+    }
+
+    pub fn get_output_data(&self) -> &[ApiAttribute] {
+        &self.output_data
+    }
+
+    pub fn add_input_definition(&mut self, def: Arc<ApiStreamDefinition>) {
+        self.input_definitions.push(def);
+    }
+
+    pub fn set_output_definition(&mut self, def: ApiStreamDefinition) {
+        self.output_stream_definition = Some(Arc::new(def));
+    }
+
+    pub fn get_output_stream_definition(&self) -> Option<&Arc<ApiStreamDefinition>> {
+        self.output_stream_definition.as_ref()
+    }
+
+    pub fn add_output_data_allowing_duplicate(&mut self, attr: ApiAttribute) {
+        self.output_data.push(attr);
+    }
+
+    pub fn clone_meta_stream_event(&self) -> Self {
+        Self {
+            input_stream_definition: self.input_stream_definition.clone(),
+            attribute_info: self.attribute_info.clone(),
+            before_window_data: self.before_window_data.clone(),
+            on_after_window_data: self.on_after_window_data.clone(),
+            output_data: self.output_data.clone(),
+            input_definitions: self.input_definitions.clone(),
+            input_reference_id: self.input_reference_id.clone(),
+            output_stream_definition: self.output_stream_definition.clone(),
+            event_type: self.event_type,
+            multi_value: self.multi_value,
+        }
     }
 
     // This method was in the prompt. It might be useful for constructing output events
@@ -89,7 +137,14 @@ impl Default for MetaStreamEvent {
         Self {
             input_stream_definition: Arc::new(ApiStreamDefinition::default()),
             attribute_info: HashMap::new(),
+            before_window_data: Vec::new(),
+            on_after_window_data: Vec::new(),
+            output_data: Vec::new(),
+            input_definitions: Vec::new(),
+            input_reference_id: None,
+            output_stream_definition: None,
             event_type: MetaStreamEventType::default(),
+            multi_value: false,
         }
     }
 }

--- a/siddhi_rust/src/core/event/stream/mod.rs
+++ b/siddhi_rust/src/core/event/stream/mod.rs
@@ -2,9 +2,11 @@
 
 pub mod stream_event;
 pub mod meta_stream_event;
-// pub mod stream_event_factory;
-// pub mod operation;
+pub mod stream_event_factory;
+pub mod operation;
 
 pub use self::stream_event::StreamEvent;
 pub use self::meta_stream_event::{MetaStreamEvent, MetaStreamEventType}; // Also export MetaStreamEventType
+pub use self::stream_event_factory::StreamEventFactory;
+pub use self::operation::{Operation, Operator};
 // ComplexEventType should be used via crate::core::event::ComplexEventType

--- a/siddhi_rust/src/core/event/stream/operation.rs
+++ b/siddhi_rust/src/core/event/stream/operation.rs
@@ -1,0 +1,27 @@
+// siddhi_rust/src/core/event/stream/operation.rs
+// Corresponds to io.siddhi.core.event.stream.Operation
+#[derive(Debug)]
+pub struct Operation {
+    pub operation: Operator,
+    pub parameters: Option<Box<dyn std::any::Any + Send + Sync>>,
+}
+
+impl Operation {
+    pub fn new(operation: Operator) -> Self {
+        Self { operation, parameters: None }
+    }
+
+    pub fn with_parameters(operation: Operator, parameters: Box<dyn std::any::Any + Send + Sync>) -> Self {
+        Self { operation, parameters: Some(parameters) }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Operator {
+    Add,
+    Remove,
+    Clear,
+    Overwrite,
+    DeleteByOperator,
+    DeleteByIndex,
+}

--- a/siddhi_rust/src/core/event/stream/stream_event_factory.rs
+++ b/siddhi_rust/src/core/event/stream/stream_event_factory.rs
@@ -1,0 +1,29 @@
+// siddhi_rust/src/core/event/stream/stream_event_factory.rs
+// Corresponds to io.siddhi.core.event.stream.StreamEventFactory
+use super::meta_stream_event::MetaStreamEvent;
+use super::stream_event::StreamEvent;
+
+#[derive(Debug, Clone)]
+pub struct StreamEventFactory {
+    pub before_window_data_size: usize,
+    pub on_after_window_data_size: usize,
+    pub output_data_size: usize,
+}
+
+impl StreamEventFactory {
+    pub fn new(before_window_data_size: usize, on_after_window_data_size: usize, output_data_size: usize) -> Self {
+        Self { before_window_data_size, on_after_window_data_size, output_data_size }
+    }
+
+    pub fn from_meta(meta: &MetaStreamEvent) -> Self {
+        Self {
+            before_window_data_size: meta.get_before_window_data().len(),
+            on_after_window_data_size: meta.get_on_after_window_data().len(),
+            output_data_size: meta.get_output_data().len(),
+        }
+    }
+
+    pub fn new_instance(&self) -> StreamEvent {
+        StreamEvent::new(0, self.before_window_data_size, self.on_after_window_data_size, self.output_data_size)
+    }
+}


### PR DESCRIPTION
## Summary
- implement missing structures in `core::event::state` and `core::event::stream`
- add `MetaStateEventAttribute` and `StateEventFactory`
- extend `MetaStreamEvent` with meta information APIs
- provide `StreamEventFactory` and `Operation`
- flesh out attribute access helpers in `StateEvent`
- document current module status

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6842694ee8708325b7dd47831ea9909c