### PR TITLE
Implement stream subscription helpers and docs

### DIFF
--- a/siddhi_rust/src/core/siddhi_app_runtime.rs
+++ b/siddhi_rust/src/core/siddhi_app_runtime.rs
@@ -90,7 +90,7 @@ impl SiddhiAppRuntime {
             query_context_for_callback,
             // query_name_for_callback, // query_name is now in query_context
         )));
-        output_junction.lock().expect("Output StreamJunction Mutex poisoned").add_subscriber(callback_processor);
+        output_junction.lock().expect("Output StreamJunction Mutex poisoned").subscribe(callback_processor);
         Ok(())
     }
 

--- a/siddhi_rust/src/core/stream/README.md
+++ b/siddhi_rust/src/core/stream/README.md
@@ -9,6 +9,9 @@ thread barriers are represented by placeholders.
 
 * `StreamJunction` – routes events between publishers and subscribers.  Supports
   optional asynchronous processing using a bounded channel.
+  `subscribe` and `unsubscribe` mirror the Java methods for managing
+  downstream processors.  `start_processing`/`stop_processing` start or
+  shut down the internal async task.
 * `Publisher` – equivalent to the Java inner class. Implements the
   `InputProcessor` trait so it can be used by the input subsystem.
 * `InputHandler`, `InputManager`, `InputDistributor` and `InputEntryValve` –

--- a/siddhi_rust/src/core/stream/input/README.md
+++ b/siddhi_rust/src/core/stream/input/README.md
@@ -1,0 +1,17 @@
+# Input Submodule
+
+Rust port of Siddhi's `io.siddhi.core.stream.input` package.  The
+implementation mirrors the Java classes where possible but remains
+simplified.
+
+## Notes
+
+* `InputHandler`, `InputManager`, `InputDistributor` and
+  `InputEntryValve` follow the same responsibilities as in the Java
+  implementation.  Thread barriers and metrics are represented by
+  placeholders.
+* `TableInputHandler` is largely unimplemented because table support is
+  missing in this prototype.
+* The event injection API is functional for the basic stateless query
+  paths used in the current integration tests.
+

--- a/siddhi_rust/src/core/stream/output/README.md
+++ b/siddhi_rust/src/core/stream/output/README.md
@@ -1,0 +1,13 @@
+# Output Submodule
+
+Partial port of Siddhi's `io.siddhi.core.stream.output` package.
+`StreamCallback` trait models the Java abstract class and a simple
+`LogStreamCallback` implementation is provided for tests.
+
+## Notes
+
+* Only callback based output is currently supported.  Sink adapters and
+  mappers are not yet implemented.
+* `to_map` helpers mimic the Java convenience methods for converting an
+  `Event` into a `HashMap` when a stream definition is available.
+

--- a/siddhi_rust/src/core/stream/output/stream_callback.rs
+++ b/siddhi_rust/src/core/stream/output/stream_callback.rs
@@ -66,6 +66,30 @@ pub trait StreamCallback: StreamJunctionReceiver + Debug + Send + Sync {
         self.receive_events(events);
     }
 
+    fn to_map(&self, event: &Event, definition: &AbstractDefinitionApi) -> Option<HashMap<String, Option<crate::core::event::value::AttributeValue>>> {
+        let mut map = HashMap::new();
+        let attrs = &definition.attribute_list;
+        if attrs.len() != event.data.len() {
+            return None;
+        }
+        map.insert("_timestamp".to_string(), Some(crate::core::event::value::AttributeValue::Long(event.timestamp)));
+        for (attr, value) in attrs.iter().zip(event.data.iter()) {
+            map.insert(attr.name.clone(), Some(value.clone()));
+        }
+        Some(map)
+    }
+
+    fn to_map_array(&self, events: &[Event], definition: &AbstractDefinitionApi) -> Option<Vec<HashMap<String, Option<crate::core::event::value::AttributeValue>>>> {
+        let mut vec = Vec::new();
+        for e in events {
+            if let Some(m) = self.to_map(e, definition) {
+                vec.push(m);
+            }
+        }
+        Some(vec)
+    }
+
+
     // Default provided methods from Java StreamCallback (if any beyond Receiver impl)
     // e.g., toMap - this requires streamDefinition to be accessible.
     // If StreamCallback structs store their StreamDefinition:

--- a/siddhi_rust/src/core/util/parser/query_parser.rs
+++ b/siddhi_rust/src/core/util/parser/query_parser.rs
@@ -183,7 +183,7 @@ impl QueryParser {
 
         // 8. Register the entry processor with the input stream junction
         if let Some(head_proc_arc) = &query_runtime.processor_chain_head {
-            input_junction.lock().expect("Input junction Mutex poisoned").add_subscriber(Arc::clone(head_proc_arc));
+            input_junction.lock().expect("Input junction Mutex poisoned").subscribe(Arc::clone(head_proc_arc));
         } else {
             // This might be valid if a query only defines things but has no direct input-to-output flow
             // (e.g. a query that only defines named windows used by other queries).


### PR DESCRIPTION
## Summary
- add subscribe/unsubscribe/start_processing helpers to `StreamJunction`
- implement `to_map` utilities for output callbacks
- document input and output submodules
- update parser and runtime to use new subscribe API

## Testing
- `cargo check --manifest-path siddhi_rust/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_68426eb293dc8325b45f944c597ec018