### PR TITLE
Enhance expression parsing and type resolution

### DIFF
--- a/siddhi_rust/src/core/executor/condition/compare_expression_executor.rs
+++ b/siddhi_rust/src/core/executor/condition/compare_expression_executor.rs
@@ -112,12 +112,153 @@ impl ExpressionExecutor for CompareExpressionExecutor {
                             return Some(AttributeValue::Bool(false));
                         }
                     }
-                    // TODO: Add type promotion/coercion logic for mixed types (e.g., Int vs Long, Int vs Float)
-                    // For now, strict type equality is required for comparison apart from Null handling.
+                    // Mixed numeric comparisons with coercion
+                    (AttributeValue::Int(l), AttributeValue::Long(r)) => {
+                        let l = *l as i64;
+                        let r = *r;
+                        match self.operator {
+                            ConditionCompareOperator::Equal => l == r,
+                            ConditionCompareOperator::NotEqual => l != r,
+                            ConditionCompareOperator::GreaterThan => l > r,
+                            ConditionCompareOperator::GreaterThanEqual => l >= r,
+                            ConditionCompareOperator::LessThan => l < r,
+                            ConditionCompareOperator::LessThanEqual => l <= r,
+                        }
+                    }
+                    (AttributeValue::Long(l), AttributeValue::Int(r)) => {
+                        let l = *l;
+                        let r = *r as i64;
+                        match self.operator {
+                            ConditionCompareOperator::Equal => l == r,
+                            ConditionCompareOperator::NotEqual => l != r,
+                            ConditionCompareOperator::GreaterThan => l > r,
+                            ConditionCompareOperator::GreaterThanEqual => l >= r,
+                            ConditionCompareOperator::LessThan => l < r,
+                            ConditionCompareOperator::LessThanEqual => l <= r,
+                        }
+                    }
+                    (AttributeValue::Int(l), AttributeValue::Float(r)) => {
+                        let l = *l as f32;
+                        let r = *r;
+                        match self.operator {
+                            ConditionCompareOperator::Equal => (l - r).abs() < f32::EPSILON,
+                            ConditionCompareOperator::NotEqual => (l - r).abs() >= f32::EPSILON,
+                            ConditionCompareOperator::GreaterThan => l > r,
+                            ConditionCompareOperator::GreaterThanEqual => l >= r,
+                            ConditionCompareOperator::LessThan => l < r,
+                            ConditionCompareOperator::LessThanEqual => l <= r,
+                        }
+                    }
+                    (AttributeValue::Float(l), AttributeValue::Int(r)) => {
+                        let l = *l;
+                        let r = *r as f32;
+                        match self.operator {
+                            ConditionCompareOperator::Equal => (l - r).abs() < f32::EPSILON,
+                            ConditionCompareOperator::NotEqual => (l - r).abs() >= f32::EPSILON,
+                            ConditionCompareOperator::GreaterThan => l > r,
+                            ConditionCompareOperator::GreaterThanEqual => l >= r,
+                            ConditionCompareOperator::LessThan => l < r,
+                            ConditionCompareOperator::LessThanEqual => l <= r,
+                        }
+                    }
+                    (AttributeValue::Int(l), AttributeValue::Double(r)) => {
+                        let l = *l as f64;
+                        let r = *r;
+                        match self.operator {
+                            ConditionCompareOperator::Equal => (l - r).abs() < f64::EPSILON,
+                            ConditionCompareOperator::NotEqual => (l - r).abs() >= f64::EPSILON,
+                            ConditionCompareOperator::GreaterThan => l > r,
+                            ConditionCompareOperator::GreaterThanEqual => l >= r,
+                            ConditionCompareOperator::LessThan => l < r,
+                            ConditionCompareOperator::LessThanEqual => l <= r,
+                        }
+                    }
+                    (AttributeValue::Double(l), AttributeValue::Int(r)) => {
+                        let l = *l;
+                        let r = *r as f64;
+                        match self.operator {
+                            ConditionCompareOperator::Equal => (l - r).abs() < f64::EPSILON,
+                            ConditionCompareOperator::NotEqual => (l - r).abs() >= f64::EPSILON,
+                            ConditionCompareOperator::GreaterThan => l > r,
+                            ConditionCompareOperator::GreaterThanEqual => l >= r,
+                            ConditionCompareOperator::LessThan => l < r,
+                            ConditionCompareOperator::LessThanEqual => l <= r,
+                        }
+                    }
+                    (AttributeValue::Long(l), AttributeValue::Float(r)) => {
+                        let l = *l as f32;
+                        let r = *r;
+                        match self.operator {
+                            ConditionCompareOperator::Equal => (l - r).abs() < f32::EPSILON,
+                            ConditionCompareOperator::NotEqual => (l - r).abs() >= f32::EPSILON,
+                            ConditionCompareOperator::GreaterThan => l > r,
+                            ConditionCompareOperator::GreaterThanEqual => l >= r,
+                            ConditionCompareOperator::LessThan => l < r,
+                            ConditionCompareOperator::LessThanEqual => l <= r,
+                        }
+                    }
+                    (AttributeValue::Float(l), AttributeValue::Long(r)) => {
+                        let l = *l;
+                        let r = *r as f32;
+                        match self.operator {
+                            ConditionCompareOperator::Equal => (l - r).abs() < f32::EPSILON,
+                            ConditionCompareOperator::NotEqual => (l - r).abs() >= f32::EPSILON,
+                            ConditionCompareOperator::GreaterThan => l > r,
+                            ConditionCompareOperator::GreaterThanEqual => l >= r,
+                            ConditionCompareOperator::LessThan => l < r,
+                            ConditionCompareOperator::LessThanEqual => l <= r,
+                        }
+                    }
+                    (AttributeValue::Long(l), AttributeValue::Double(r)) => {
+                        let l = *l as f64;
+                        let r = *r;
+                        match self.operator {
+                            ConditionCompareOperator::Equal => (l - r).abs() < f64::EPSILON,
+                            ConditionCompareOperator::NotEqual => (l - r).abs() >= f64::EPSILON,
+                            ConditionCompareOperator::GreaterThan => l > r,
+                            ConditionCompareOperator::GreaterThanEqual => l >= r,
+                            ConditionCompareOperator::LessThan => l < r,
+                            ConditionCompareOperator::LessThanEqual => l <= r,
+                        }
+                    }
+                    (AttributeValue::Double(l), AttributeValue::Long(r)) => {
+                        let l = *l;
+                        let r = *r as f64;
+                        match self.operator {
+                            ConditionCompareOperator::Equal => (l - r).abs() < f64::EPSILON,
+                            ConditionCompareOperator::NotEqual => (l - r).abs() >= f64::EPSILON,
+                            ConditionCompareOperator::GreaterThan => l > r,
+                            ConditionCompareOperator::GreaterThanEqual => l >= r,
+                            ConditionCompareOperator::LessThan => l < r,
+                            ConditionCompareOperator::LessThanEqual => l <= r,
+                        }
+                    }
+                    (AttributeValue::Float(l), AttributeValue::Double(r)) => {
+                        let l = *l as f64;
+                        let r = *r;
+                        match self.operator {
+                            ConditionCompareOperator::Equal => (l - r).abs() < f64::EPSILON,
+                            ConditionCompareOperator::NotEqual => (l - r).abs() >= f64::EPSILON,
+                            ConditionCompareOperator::GreaterThan => l > r,
+                            ConditionCompareOperator::GreaterThanEqual => l >= r,
+                            ConditionCompareOperator::LessThan => l < r,
+                            ConditionCompareOperator::LessThanEqual => l <= r,
+                        }
+                    }
+                    (AttributeValue::Double(l), AttributeValue::Float(r)) => {
+                        let l = *l;
+                        let r = *r as f64;
+                        match self.operator {
+                            ConditionCompareOperator::Equal => (l - r).abs() < f64::EPSILON,
+                            ConditionCompareOperator::NotEqual => (l - r).abs() >= f64::EPSILON,
+                            ConditionCompareOperator::GreaterThan => l > r,
+                            ConditionCompareOperator::GreaterThanEqual => l >= r,
+                            ConditionCompareOperator::LessThan => l < r,
+                            ConditionCompareOperator::LessThanEqual => l <= r,
+                        }
+                    }
                     _ => {
-                        // log_warn!("Unsupported type combination for comparison: {:?} and {:?}", left.get_type(), right.get_type());
-                        // If types are different and not handled by coercion, consider it false or error.
-                        return Some(AttributeValue::Bool(false)); // Default to false if types are incompatible
+                        return Some(AttributeValue::Bool(false));
                     }
                 };
                 Some(AttributeValue::Bool(result))

--- a/siddhi_rust/src/core/util/parser/query_parser.rs
+++ b/siddhi_rust/src/core/util/parser/query_parser.rs
@@ -71,12 +71,15 @@ impl QueryParser {
 
         let input_stream_def_from_junction = input_junction.lock().expect("Input junction Mutex poisoned").get_stream_definition();
 
-        // 3. Create MetaStreamEvent for ExpressionParserContext (based on single input stream)
+        // 3. Create MetaStreamEvent map for ExpressionParserContext
         let meta_input_event = Arc::new(MetaStreamEvent::new_for_single_input(input_stream_def_from_junction));
+        let mut stream_meta_map = HashMap::new();
+        stream_meta_map.insert(input_stream_id.clone(), Arc::clone(&meta_input_event));
         let expr_parser_context = ExpressionParserContext {
             siddhi_app_context: Arc::clone(siddhi_app_context),
-            meta_input_event: Arc::clone(&meta_input_event),
-            query_name: &query_name, // Pass as reference
+            stream_meta_map,
+            default_source: input_stream_id.clone(),
+            query_name: &query_name,
         };
 
         let mut processor_chain_head: Option<Arc<Mutex<dyn Processor>>> = None;

--- a/siddhi_rust/tests/expression_parser_complex.rs
+++ b/siddhi_rust/tests/expression_parser_complex.rs
@@ -1,0 +1,88 @@
+use siddhi_rust::core::util::parser::{parse_expression, ExpressionParserContext};
+use siddhi_rust::query_api::expression::{Expression, Variable};
+use siddhi_rust::query_api::expression::condition::compare::Operator as CompareOp;
+use siddhi_rust::query_api::definition::{StreamDefinition, attribute::Type as AttrType};
+use siddhi_rust::core::event::stream::meta_stream_event::MetaStreamEvent;
+use siddhi_rust::core::config::siddhi_app_context::SiddhiAppContext;
+use siddhi_rust::core::config::siddhi_context::SiddhiContext;
+use siddhi_rust::query_api::siddhi_app::SiddhiApp;
+use std::sync::Arc;
+use std::collections::HashMap;
+
+fn make_app_ctx() -> Arc<SiddhiAppContext> {
+    Arc::new(SiddhiAppContext::new(
+        Arc::new(SiddhiContext::default()),
+        "test".to_string(),
+        Arc::new(SiddhiApp::new("app".to_string())),
+        String::new(),
+    ))
+}
+
+#[test]
+fn test_parse_expression_multi_stream_variable() {
+    let stream_a = StreamDefinition::new("A".to_string())
+        .attribute("val".to_string(), AttrType::INT);
+    let stream_b = StreamDefinition::new("B".to_string())
+        .attribute("val".to_string(), AttrType::DOUBLE);
+
+    let meta_a = Arc::new(MetaStreamEvent::new_for_single_input(Arc::new(stream_a)));
+    let meta_b = Arc::new(MetaStreamEvent::new_for_single_input(Arc::new(stream_b)));
+
+    let mut map = HashMap::new();
+    map.insert("A".to_string(), Arc::clone(&meta_a));
+    map.insert("B".to_string(), Arc::clone(&meta_b));
+
+    let ctx = ExpressionParserContext {
+        siddhi_app_context: make_app_ctx(),
+        stream_meta_map: map,
+        default_source: "A".to_string(),
+        query_name: "Q1",
+    };
+
+    let var_a = Variable::new("val".to_string()).of_stream("A".to_string());
+    let var_b = Variable::new("val".to_string()).of_stream("B".to_string());
+    let expr = Expression::compare(Expression::Variable(var_a), CompareOp::LessThan, Expression::Variable(var_b));
+
+    let exec = parse_expression(&expr, &ctx).expect("parse failed");
+    assert_eq!(exec.get_return_type(), AttrType::BOOL);
+}
+
+#[test]
+fn test_compare_type_coercion_int_double() {
+    let ctx = ExpressionParserContext {
+        siddhi_app_context: make_app_ctx(),
+        stream_meta_map: HashMap::new(),
+        default_source: "dummy".to_string(),
+        query_name: "Q2",
+    };
+
+    let expr = Expression::compare(
+        Expression::value_int(5),
+        CompareOp::LessThan,
+        Expression::value_double(5.5),
+    );
+    let exec = parse_expression(&expr, &ctx).unwrap();
+    let result = exec.execute(None);
+    assert_eq!(result, Some(siddhi_rust::core::event::value::AttributeValue::Bool(true)));
+}
+
+#[test]
+fn test_variable_not_found_error() {
+    let stream_a = StreamDefinition::new("A".to_string())
+        .attribute("val".to_string(), AttrType::INT);
+    let meta_a = Arc::new(MetaStreamEvent::new_for_single_input(Arc::new(stream_a)));
+    let mut map = HashMap::new();
+    map.insert("A".to_string(), Arc::clone(&meta_a));
+
+    let ctx = ExpressionParserContext {
+        siddhi_app_context: make_app_ctx(),
+        stream_meta_map: map,
+        default_source: "A".to_string(),
+        query_name: "Q3",
+    };
+
+    let var_b = Variable::new("missing".to_string()).of_stream("A".to_string());
+    let expr = Expression::Variable(var_b);
+    let err = parse_expression(&expr, &ctx).unwrap_err();
+    assert!(err.contains("Q3"));
+}


### PR DESCRIPTION
## Summary
- improve expression parser context for multi-stream variable resolution
- enrich error messages with query context info
- coerce numeric types in CompareExpressionExecutor
- add tests for complex expressions

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6843e7f774348325a2c0a5cd8766451c