### PR TITLE
Implement basic table operations

### DIFF
--- a/siddhi_rust/src/core/table/mod.rs
+++ b/siddhi_rust/src/core/table/mod.rs
@@ -1,0 +1,87 @@
+use crate::core::event::value::AttributeValue;
+use std::sync::RwLock;
+use std::fmt::Debug;
+
+/// Trait representing a table that can store rows of `AttributeValue`s.
+pub trait Table: Debug + Send + Sync {
+    /// Inserts a row into the table.
+    fn insert(&self, values: &[AttributeValue]);
+
+    /// Updates rows matching `old_values` with `new_values`.
+    /// Returns `true` if any row was updated.
+    fn update(&self, old_values: &[AttributeValue], new_values: &[AttributeValue]) -> bool;
+
+    /// Deletes rows matching `values` from the table.
+    /// Returns `true` if any row was removed.
+    fn delete(&self, values: &[AttributeValue]) -> bool;
+
+    /// Finds the first row matching `values` and returns a clone of it.
+    fn find(&self, values: &[AttributeValue]) -> Option<Vec<AttributeValue>>;
+
+    /// Returns `true` if the table contains the given row.
+    fn contains(&self, values: &[AttributeValue]) -> bool;
+
+    /// Clone helper for boxed trait objects.
+    fn clone_table(&self) -> Box<dyn Table>;
+}
+
+impl Clone for Box<dyn Table> {
+    fn clone(&self) -> Self {
+        self.clone_table()
+    }
+}
+
+/// Simple in-memory table storing rows in a vector.
+#[derive(Debug, Default)]
+pub struct InMemoryTable {
+    rows: RwLock<Vec<Vec<AttributeValue>>>,
+}
+
+impl InMemoryTable {
+    pub fn new() -> Self {
+        Self { rows: RwLock::new(Vec::new()) }
+    }
+}
+
+impl Table for InMemoryTable {
+    fn insert(&self, values: &[AttributeValue]) {
+        self.rows.write().unwrap().push(values.to_vec());
+    }
+
+    fn update(&self, old_values: &[AttributeValue], new_values: &[AttributeValue]) -> bool {
+        let mut rows = self.rows.write().unwrap();
+        let mut updated = false;
+        for row in rows.iter_mut() {
+            if row.as_slice() == old_values {
+                *row = new_values.to_vec();
+                updated = true;
+            }
+        }
+        updated
+    }
+
+    fn delete(&self, values: &[AttributeValue]) -> bool {
+        let mut rows = self.rows.write().unwrap();
+        let original_len = rows.len();
+        rows.retain(|row| row.as_slice() != values);
+        original_len != rows.len()
+    }
+
+    fn find(&self, values: &[AttributeValue]) -> Option<Vec<AttributeValue>> {
+        self.rows
+            .read()
+            .unwrap()
+            .iter()
+            .find(|row| row.as_slice() == values)
+            .cloned()
+    }
+
+    fn contains(&self, values: &[AttributeValue]) -> bool {
+        self.rows.read().unwrap().iter().any(|row| row == values)
+    }
+
+    fn clone_table(&self) -> Box<dyn Table> {
+        let rows = self.rows.read().unwrap().clone();
+        Box::new(InMemoryTable { rows: RwLock::new(rows) })
+    }
+}

--- a/siddhi_rust/tests/in_memory_table.rs
+++ b/siddhi_rust/tests/in_memory_table.rs
@@ -1,0 +1,55 @@
+use siddhi_rust::core::table::{InMemoryTable, Table};
+use siddhi_rust::core::event::value::AttributeValue;
+
+#[test]
+fn test_insert_and_contains() {
+    let table = InMemoryTable::new();
+    let row = vec![
+        AttributeValue::Int(1),
+        AttributeValue::String("a".to_string()),
+    ];
+    table.insert(&row);
+    assert!(table.contains(&row));
+}
+
+#[test]
+fn test_contains_false() {
+    let table = InMemoryTable::new();
+    let row1 = vec![AttributeValue::Int(2)];
+    let row2 = vec![AttributeValue::Int(3)];
+    table.insert(&row1);
+    assert!(!table.contains(&row2));
+}
+
+#[test]
+fn test_update() {
+    let table = InMemoryTable::new();
+    let old = vec![AttributeValue::Int(1)];
+    let new = vec![AttributeValue::Int(2)];
+    table.insert(&old);
+    assert!(table.update(&old, &new));
+    assert!(!table.contains(&old));
+    assert!(table.contains(&new));
+}
+
+#[test]
+fn test_delete() {
+    let table = InMemoryTable::new();
+    let row1 = vec![AttributeValue::Int(1)];
+    let row2 = vec![AttributeValue::Int(2)];
+    table.insert(&row1);
+    table.insert(&row2);
+    assert!(table.delete(&row1));
+    assert!(!table.contains(&row1));
+    assert!(table.contains(&row2));
+}
+
+#[test]
+fn test_find() {
+    let table = InMemoryTable::new();
+    let row = vec![AttributeValue::Int(42)];
+    table.insert(&row);
+    let found = table.find(&row);
+    assert_eq!(found, Some(row.clone()));
+    assert!(table.find(&[AttributeValue::Int(0)]).is_none());
+}


### PR DESCRIPTION
## Summary
- extend `Table` trait with update, delete and find operations
- implement these in `InMemoryTable`
- test insertion, update, deletion and lookup

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684406228a40832599765ab6534f62ce