### PR TITLE
Add table lookup support for IN expression

### DIFF
--- a/siddhi_rust/README.md
+++ b/siddhi_rust/README.md
@@ -34,7 +34,10 @@ This port is **far from feature-complete** with the Java version. Users should b
 *   **`ExpressionExecutor` Implementations**:
     *   `VariableExpressionExecutor`: `execute` method uses a simplified data access model (assumes data in `StreamEvent::output_data` or `before_window_data` via a simple index). Needs to correctly handle different event types, data arrays (input, output, before/after window data), and dynamic resolution (tables, stores).
     *   `CompareExpressionExecutor`: Currently only implements basic integer comparison for `>`. Full type comparison logic (all numeric types, strings, bools, temporal, null handling) for all operators is missing.
-    *   `InExpressionExecutor`: Placeholder.
+    *   `InExpressionExecutor`: Provides a basic `IN` operator. It evaluates the inner
+        expression and checks membership using `Table::contains`. The full
+        Siddhi semantics of compiling a condition and using
+        `Table::containsEvent` are **not** implemented yet.
     *   Many function executors (casts, conversions, string ops, date ops, math ops beyond basic arithmetic) are not ported.
     *   Stateful function executors are not handled.
 *   **Stream Processors & Query Logic**:
@@ -44,7 +47,9 @@ This port is **far from feature-complete** with the Java version. Users should b
     *   **Patterns & Sequences**: No pattern or sequence processors implemented.
     *   **Aggregations**: No aggregation runtime or aggregator functions ported.
 *   **State Management & Persistence**:
-    *   **Tables**: No `Table` implementations (in-memory, RDBMS via DataSource) or table operation processors (update, delete, in-table select/join) are ported.
+    *   **Tables**: A simple `InMemoryTable` is available for tests. It supports
+        insertion and basic lookup operations but lacks compiled condition queries or
+        persistent storage backends.
     *   **Persistence**: `SnapshotService` and `PersistenceStore` framework is not implemented. No state persistence or recovery.
 *   **Runtime & Orchestration**:
     *   `SiddhiAppParser` & `QueryParser`: Can only handle very simple queries (single stream, optional filter, simple select, insert into). Cannot parse partitions, windows, joins, patterns, sequences, tables, aggregations.

--- a/siddhi_rust/src/core/executor/condition/in_expression_executor.rs
+++ b/siddhi_rust/src/core/executor/condition/in_expression_executor.rs
@@ -6,13 +6,7 @@ use crate::core::event::value::AttributeValue;
 use crate::query_api::definition::attribute::Type as ApiAttributeType; // Import Type enum
 use std::sync::Arc; // For SiddhiAppContext in clone_executor
 use crate::core::config::siddhi_app_context::SiddhiAppContext; // For clone_executor
-// use crate::core::table::Table; // TODO: Define Table trait/struct
-// use crate::core::util::collection::operator::CompiledCondition; // TODO: Define CompiledCondition
-
-// Placeholder for Table and CompiledCondition
-#[derive(Debug, Clone)] pub struct TablePlaceholder {}
-#[derive(Debug, Clone)] pub struct CompiledConditionPlaceholder {}
-
+use crate::core::table::Table;
 
 #[derive(Debug)]
 pub struct InExpressionExecutor {
@@ -23,28 +17,22 @@ pub struct InExpressionExecutor {
     // private final CompiledCondition compiledCondition;
     // private Table table;
 
-    // Simplified placeholder fields for now
+    // Simplified implementation fields
     value_executor: Box<dyn ExpressionExecutor>, // Executes the expression whose value is checked for "IN"
-    // table: Arc<dyn Table>, // The table to check for presence
-    // compiled_condition_for_table_lookup: CompiledConditionPlaceholder, // Pre-compiled condition for efficient lookup
-
-    // For now, just a placeholder string for what would be a more complex collection/table lookup
-    collection_placeholder: String,
+    table_id: String,
+    siddhi_app_context: Arc<SiddhiAppContext>,
 }
 
 impl InExpressionExecutor {
     pub fn new(
         value_executor: Box<dyn ExpressionExecutor>,
-        // table: Arc<dyn Table>,
-        // compiled_condition: CompiledConditionPlaceholder,
-        // stream_event_size: usize, // etc.
-        collection_placeholder: String // Simplified
+        table_id: String,
+        siddhi_app_context: Arc<SiddhiAppContext>,
     ) -> Self {
         Self {
             value_executor,
-            // table,
-            // compiled_condition,
-            collection_placeholder
+            table_id,
+            siddhi_app_context,
         }
     }
 }
@@ -52,18 +40,29 @@ impl InExpressionExecutor {
 impl ExpressionExecutor for InExpressionExecutor {
     fn execute(&self, event: Option<&dyn ComplexEvent>) -> Option<AttributeValue> {
         let value_to_check = self.value_executor.execute(event);
-        if value_to_check.is_none() || matches!(value_to_check, Some(AttributeValue::Null)) {
-            return Some(AttributeValue::Bool(false)); // IN null is generally false or null
+        let value = match value_to_check {
+            Some(v) => {
+                if matches!(v, AttributeValue::Null) {
+                    return Some(AttributeValue::Bool(false));
+                }
+                v
+            }
+            None => return Some(AttributeValue::Bool(false)),
+        };
+
+        let table_opt = self
+            .siddhi_app_context
+            .get_siddhi_context()
+            .get_table(&self.table_id);
+
+        if let Some(table) = table_opt {
+            let key = vec![value.clone()];
+            let contains = table.contains(&key);
+            Some(AttributeValue::Bool(contains))
+        } else {
+            // If the table is not found, treat as false
+            Some(AttributeValue::Bool(false))
         }
-        // TODO: Implement actual "IN" logic.
-        // This involves:
-        // 1. Getting the value from value_to_check.
-        // 2. Checking if this value exists in the specified table/collection,
-        //    potentially using the compiled_condition against the table.
-        //    The Java code uses `table.containsEvent(finderStateEvent, compiledCondition)`.
-        //    This requires FinderStateEvent, and table interaction logic.
-        println!("[InExpressionExecutor] Value to check: {:?}, Collection: {}", value_to_check, self.collection_placeholder);
-        Some(AttributeValue::Bool(false)) // Placeholder: always return false
     }
 
     fn get_return_type(&self) -> ApiAttributeType {
@@ -71,11 +70,10 @@ impl ExpressionExecutor for InExpressionExecutor {
     }
 
     fn clone_executor(&self, siddhi_app_context: &Arc<SiddhiAppContext>) -> Box<dyn ExpressionExecutor> {
-        // Cloning this would be complex due to Table reference and CompiledCondition in a full impl.
-        // For the current placeholder, it's simpler.
         Box::new(InExpressionExecutor::new(
             self.value_executor.clone_executor(siddhi_app_context),
-            self.collection_placeholder.clone()
+            self.table_id.clone(),
+            Arc::clone(siddhi_app_context),
         ))
     }
 }

--- a/siddhi_rust/src/core/util/parser/expression_parser.rs
+++ b/siddhi_rust/src/core/util/parser/expression_parser.rs
@@ -259,7 +259,11 @@ pub fn parse_expression<'a>( // Added lifetime 'a
         }
         ApiExpression::In(api_op) => {
             let val_exec = parse_expression(&api_op.expression, context)?;
-            Ok(Box::new(InExpressionExecutor::new(val_exec, api_op.source_id.clone())))
+            Ok(Box::new(InExpressionExecutor::new(
+                val_exec,
+                api_op.source_id.clone(),
+                Arc::clone(&context.siddhi_app_context),
+            )))
         }
         ApiExpression::AttributeFunction(api_func) => {
             let mut arg_execs: Vec<Box<dyn ExpressionExecutor>> = Vec::new();

--- a/siddhi_rust/tests/in_expression_executor.rs
+++ b/siddhi_rust/tests/in_expression_executor.rs
@@ -1,0 +1,60 @@
+use siddhi_rust::core::executor::condition::InExpressionExecutor;
+use siddhi_rust::core::executor::constant_expression_executor::ConstantExpressionExecutor;
+use siddhi_rust::core::executor::expression_executor::ExpressionExecutor;
+use siddhi_rust::core::table::{InMemoryTable, Table};
+use siddhi_rust::core::config::siddhi_app_context::SiddhiAppContext;
+use siddhi_rust::core::config::siddhi_context::SiddhiContext;
+use siddhi_rust::query_api::siddhi_app::SiddhiApp;
+use siddhi_rust::core::event::value::AttributeValue;
+use siddhi_rust::query_api::definition::attribute::Type as ApiAttributeType;
+use std::sync::Arc;
+
+fn make_context_with_table() -> Arc<SiddhiAppContext> {
+    let ctx = Arc::new(SiddhiAppContext::new(
+        Arc::new(SiddhiContext::default()),
+        "test_app".to_string(),
+        Arc::new(SiddhiApp::new("test".to_string())),
+        String::new(),
+    ));
+    let table: Arc<dyn Table> = Arc::new(InMemoryTable::new());
+    table.insert(&[AttributeValue::Int(1)]);
+    ctx.get_siddhi_context().add_table("MyTable".to_string(), table);
+    ctx
+}
+
+#[test]
+fn test_in_true() {
+    let app_ctx = make_context_with_table();
+    let const_exec = Box::new(ConstantExpressionExecutor::new(
+        AttributeValue::Int(1),
+        ApiAttributeType::INT,
+    ));
+    let in_exec = InExpressionExecutor::new(const_exec, "MyTable".to_string(), Arc::clone(&app_ctx));
+    let result = in_exec.execute(None);
+    assert_eq!(result, Some(AttributeValue::Bool(true)));
+}
+
+#[test]
+fn test_in_false() {
+    let app_ctx = make_context_with_table();
+    let const_exec = Box::new(ConstantExpressionExecutor::new(
+        AttributeValue::Int(5),
+        ApiAttributeType::INT,
+    ));
+    let in_exec = InExpressionExecutor::new(const_exec, "MyTable".to_string(), Arc::clone(&app_ctx));
+    let result = in_exec.execute(None);
+    assert_eq!(result, Some(AttributeValue::Bool(false)));
+}
+
+#[test]
+fn test_in_clone() {
+    let app_ctx = make_context_with_table();
+    let const_exec = Box::new(ConstantExpressionExecutor::new(
+        AttributeValue::Int(1),
+        ApiAttributeType::INT,
+    ));
+    let in_exec = InExpressionExecutor::new(const_exec, "MyTable".to_string(), Arc::clone(&app_ctx));
+    let cloned = in_exec.clone_executor(&app_ctx);
+    let result = cloned.execute(None);
+    assert_eq!(result, Some(AttributeValue::Bool(true)));
+}


### PR DESCRIPTION
## Summary
- implement `InExpressionExecutor` to perform table lookups
- wire parser to pass SiddhiAppContext
- test IN expression execution against an InMemoryTable
- document missing compiled-condition behavior in README

## Testing
- `cargo test --no-run`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684413fc6c788325ac15362adeb837ad