### PR TITLE
Add basic builtin function executors

### DIFF
--- a/siddhi_rust/Cargo.lock
+++ b/siddhi_rust/Cargo.lock
@@ -12,6 +12,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ascii-canvas"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -54,10 +69,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
+name = "cc"
+version = "1.2.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "956a5e21988b87f372569b66183b78babf23ebc2e744b733e4350a752c4dafac"
+dependencies = [
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "crossbeam-channel"
@@ -156,6 +200,30 @@ name = "hashbrown"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "indexmap"
@@ -260,6 +328,15 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "once_cell"
@@ -455,9 +532,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "siddhi_rust"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "crossbeam-channel",
  "lalrpop",
  "lalrpop-util",
@@ -677,6 +761,65 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/siddhi_rust/Cargo.toml
+++ b/siddhi_rust/Cargo.toml
@@ -12,6 +12,7 @@ uuid = { version = "1", features = ["v4"] }
 rand = "0.8"
 crossbeam-channel = "0.5"
 lalrpop-util = { version = "0.20", features = ["lexer"] }
+chrono = "0.4"
 
 [build-dependencies]
 lalrpop = "0.20"

--- a/siddhi_rust/src/core/executor/function/cast_function_executor.rs
+++ b/siddhi_rust/src/core/executor/function/cast_function_executor.rs
@@ -1,0 +1,128 @@
+// siddhi_rust/src/core/executor/function/cast_function_executor.rs
+use crate::core::executor::expression_executor::ExpressionExecutor;
+use crate::core::event::complex_event::ComplexEvent;
+use crate::core::event::value::AttributeValue;
+use crate::query_api::definition::attribute::Type as ApiAttributeType;
+use crate::core::config::siddhi_app_context::SiddhiAppContext;
+use std::sync::Arc;
+
+#[derive(Debug)]
+pub struct CastFunctionExecutor {
+    value_executor: Box<dyn ExpressionExecutor>,
+    return_type: ApiAttributeType,
+}
+
+impl CastFunctionExecutor {
+    pub fn new(
+        value_executor: Box<dyn ExpressionExecutor>,
+        type_executor: Box<dyn ExpressionExecutor>,
+    ) -> Result<Self, String> {
+        if type_executor.get_return_type() != ApiAttributeType::STRING {
+            return Err("Cast function type argument must be STRING".to_string());
+        }
+        let type_val = match type_executor.execute(None) {
+            Some(AttributeValue::String(s)) => s.to_lowercase(),
+            _ => {
+                return Err(
+                    "Cast function requires a constant string as type argument".to_string(),
+                )
+            }
+        };
+        let return_type = match type_val.as_str() {
+            "string" => ApiAttributeType::STRING,
+            "int" => ApiAttributeType::INT,
+            "long" => ApiAttributeType::LONG,
+            "float" => ApiAttributeType::FLOAT,
+            "double" => ApiAttributeType::DOUBLE,
+            "bool" | "boolean" => ApiAttributeType::BOOL,
+            "object" => ApiAttributeType::OBJECT,
+            _ => return Err(format!("Unsupported cast target type: {}", type_val)),
+        };
+        Ok(Self {
+            value_executor,
+            return_type,
+        })
+    }
+
+    fn cast_value(&self, value: AttributeValue) -> Option<AttributeValue> {
+        if matches!(value, AttributeValue::Null) {
+            return Some(AttributeValue::Null);
+        }
+        match self.return_type {
+            ApiAttributeType::STRING => Some(AttributeValue::String(match value {
+                AttributeValue::String(s) => s,
+                AttributeValue::Int(v) => v.to_string(),
+                AttributeValue::Long(v) => v.to_string(),
+                AttributeValue::Float(v) => v.to_string(),
+                AttributeValue::Double(v) => v.to_string(),
+                AttributeValue::Bool(v) => v.to_string(),
+                AttributeValue::Object(_) => "<object>".to_string(),
+                AttributeValue::Null => String::new(),
+            })),
+            ApiAttributeType::INT => match value {
+                AttributeValue::Int(v) => Some(AttributeValue::Int(v)),
+                AttributeValue::Long(v) => Some(AttributeValue::Int(v as i32)),
+                AttributeValue::Float(v) => Some(AttributeValue::Int(v as i32)),
+                AttributeValue::Double(v) => Some(AttributeValue::Int(v as i32)),
+                AttributeValue::Bool(v) => Some(AttributeValue::Int(if v { 1 } else { 0 })),
+                AttributeValue::String(s) => s.parse::<i32>().ok().map(AttributeValue::Int),
+                _ => None,
+            },
+            ApiAttributeType::LONG => match value {
+                AttributeValue::Int(v) => Some(AttributeValue::Long(v as i64)),
+                AttributeValue::Long(v) => Some(AttributeValue::Long(v)),
+                AttributeValue::Float(v) => Some(AttributeValue::Long(v as i64)),
+                AttributeValue::Double(v) => Some(AttributeValue::Long(v as i64)),
+                AttributeValue::Bool(v) => Some(AttributeValue::Long(if v { 1 } else { 0 })),
+                AttributeValue::String(s) => s.parse::<i64>().ok().map(AttributeValue::Long),
+                _ => None,
+            },
+            ApiAttributeType::FLOAT => match value {
+                AttributeValue::Int(v) => Some(AttributeValue::Float(v as f32)),
+                AttributeValue::Long(v) => Some(AttributeValue::Float(v as f32)),
+                AttributeValue::Float(v) => Some(AttributeValue::Float(v)),
+                AttributeValue::Double(v) => Some(AttributeValue::Float(v as f32)),
+                AttributeValue::Bool(v) => Some(AttributeValue::Float(if v { 1.0 } else { 0.0 })),
+                AttributeValue::String(s) => s.parse::<f32>().ok().map(AttributeValue::Float),
+                _ => None,
+            },
+            ApiAttributeType::DOUBLE => match value {
+                AttributeValue::Int(v) => Some(AttributeValue::Double(v as f64)),
+                AttributeValue::Long(v) => Some(AttributeValue::Double(v as f64)),
+                AttributeValue::Float(v) => Some(AttributeValue::Double(v as f64)),
+                AttributeValue::Double(v) => Some(AttributeValue::Double(v)),
+                AttributeValue::Bool(v) => Some(AttributeValue::Double(if v { 1.0 } else { 0.0 })),
+                AttributeValue::String(s) => s.parse::<f64>().ok().map(AttributeValue::Double),
+                _ => None,
+            },
+            ApiAttributeType::BOOL => match value {
+                AttributeValue::Bool(b) => Some(AttributeValue::Bool(b)),
+                AttributeValue::String(s) => s.parse::<bool>().ok().map(AttributeValue::Bool),
+                AttributeValue::Int(i) => Some(AttributeValue::Bool(i != 0)),
+                AttributeValue::Long(l) => Some(AttributeValue::Bool(l != 0)),
+                AttributeValue::Float(f) => Some(AttributeValue::Bool(f != 0.0)),
+                AttributeValue::Double(d) => Some(AttributeValue::Bool(d != 0.0)),
+                _ => None,
+            },
+            ApiAttributeType::OBJECT => Some(value),
+        }
+    }
+}
+
+impl ExpressionExecutor for CastFunctionExecutor {
+    fn execute(&self, event: Option<&dyn ComplexEvent>) -> Option<AttributeValue> {
+        let value = self.value_executor.execute(event)?;
+        self.cast_value(value)
+    }
+
+    fn get_return_type(&self) -> ApiAttributeType {
+        self.return_type
+    }
+
+    fn clone_executor(&self, ctx: &Arc<SiddhiAppContext>) -> Box<dyn ExpressionExecutor> {
+        Box::new(CastFunctionExecutor {
+            value_executor: self.value_executor.clone_executor(ctx),
+            return_type: self.return_type,
+        })
+    }
+}

--- a/siddhi_rust/src/core/executor/function/date_functions.rs
+++ b/siddhi_rust/src/core/executor/function/date_functions.rs
@@ -1,0 +1,74 @@
+// siddhi_rust/src/core/executor/function/date_functions.rs
+use crate::core::executor::expression_executor::ExpressionExecutor;
+use crate::core::event::complex_event::ComplexEvent;
+use crate::core::event::value::AttributeValue;
+use crate::query_api::definition::attribute::Type as ApiAttributeType;
+use crate::core::config::siddhi_app_context::SiddhiAppContext;
+use std::sync::Arc;
+use chrono::{NaiveDateTime, Utc};
+
+#[derive(Debug, Default, Clone)]
+pub struct CurrentTimestampFunctionExecutor;
+
+impl ExpressionExecutor for CurrentTimestampFunctionExecutor {
+    fn execute(&self, _event: Option<&dyn ComplexEvent>) -> Option<AttributeValue> {
+        let millis = Utc::now().timestamp_millis();
+        Some(AttributeValue::Long(millis))
+    }
+
+    fn get_return_type(&self) -> ApiAttributeType {
+        ApiAttributeType::LONG
+    }
+
+    fn clone_executor(&self, _ctx: &Arc<SiddhiAppContext>) -> Box<dyn ExpressionExecutor> {
+        Box::new(self.clone())
+    }
+}
+
+#[derive(Debug)]
+pub struct FormatDateFunctionExecutor {
+    timestamp_executor: Box<dyn ExpressionExecutor>,
+    pattern: String,
+}
+
+impl FormatDateFunctionExecutor {
+    pub fn new(
+        timestamp_executor: Box<dyn ExpressionExecutor>,
+        pattern_executor: Box<dyn ExpressionExecutor>,
+    ) -> Result<Self, String> {
+        if pattern_executor.get_return_type() != ApiAttributeType::STRING {
+            return Err("formatDate pattern must be STRING".to_string());
+        }
+        let pattern = match pattern_executor.execute(None) {
+            Some(AttributeValue::String(s)) => s,
+            _ => return Err("formatDate pattern must be constant string".to_string()),
+        };
+        Ok(Self { timestamp_executor, pattern })
+    }
+}
+
+impl ExpressionExecutor for FormatDateFunctionExecutor {
+    fn execute(&self, event: Option<&dyn ComplexEvent>) -> Option<AttributeValue> {
+        let ts_val = self.timestamp_executor.execute(event)?;
+        let ts = match ts_val {
+            AttributeValue::Long(v) => v,
+            AttributeValue::Int(v) => v as i64,
+            AttributeValue::Null => return Some(AttributeValue::Null),
+            _ => return None,
+        };
+        let ndt = NaiveDateTime::from_timestamp_millis(ts)?;
+        let formatted = ndt.format(&self.pattern).to_string();
+        Some(AttributeValue::String(formatted))
+    }
+
+    fn get_return_type(&self) -> ApiAttributeType {
+        ApiAttributeType::STRING
+    }
+
+    fn clone_executor(&self, ctx: &Arc<SiddhiAppContext>) -> Box<dyn ExpressionExecutor> {
+        Box::new(FormatDateFunctionExecutor {
+            timestamp_executor: self.timestamp_executor.clone_executor(ctx),
+            pattern: self.pattern.clone(),
+        })
+    }
+}

--- a/siddhi_rust/src/core/executor/function/math_functions.rs
+++ b/siddhi_rust/src/core/executor/function/math_functions.rs
@@ -1,0 +1,85 @@
+// siddhi_rust/src/core/executor/function/math_functions.rs
+use crate::core::executor::expression_executor::ExpressionExecutor;
+use crate::core::event::complex_event::ComplexEvent;
+use crate::core::event::value::AttributeValue;
+use crate::query_api::definition::attribute::Type as ApiAttributeType;
+use crate::core::config::siddhi_app_context::SiddhiAppContext;
+use std::sync::Arc;
+
+fn to_f64(val: &AttributeValue) -> Option<f64> {
+    match val {
+        AttributeValue::Int(v) => Some(*v as f64),
+        AttributeValue::Long(v) => Some(*v as f64),
+        AttributeValue::Float(v) => Some(*v as f64),
+        AttributeValue::Double(v) => Some(*v),
+        _ => None,
+    }
+}
+
+#[derive(Debug)]
+pub struct SqrtFunctionExecutor {
+    value_executor: Box<dyn ExpressionExecutor>,
+}
+
+impl SqrtFunctionExecutor {
+    pub fn new(value_executor: Box<dyn ExpressionExecutor>) -> Result<Self, String> {
+        Ok(Self { value_executor })
+    }
+}
+
+impl ExpressionExecutor for SqrtFunctionExecutor {
+    fn execute(&self, event: Option<&dyn ComplexEvent>) -> Option<AttributeValue> {
+        let val = self.value_executor.execute(event)?;
+        match val {
+            AttributeValue::Null => Some(AttributeValue::Null),
+            _ => {
+                let num = to_f64(&val)?;
+                Some(AttributeValue::Double(num.sqrt()))
+            }
+        }
+    }
+
+    fn get_return_type(&self) -> ApiAttributeType {
+        ApiAttributeType::DOUBLE
+    }
+
+    fn clone_executor(&self, ctx: &Arc<SiddhiAppContext>) -> Box<dyn ExpressionExecutor> {
+        Box::new(SqrtFunctionExecutor {
+            value_executor: self.value_executor.clone_executor(ctx),
+        })
+    }
+}
+
+#[derive(Debug)]
+pub struct RoundFunctionExecutor {
+    value_executor: Box<dyn ExpressionExecutor>,
+}
+
+impl RoundFunctionExecutor {
+    pub fn new(value_executor: Box<dyn ExpressionExecutor>) -> Result<Self, String> {
+        Ok(Self { value_executor })
+    }
+}
+
+impl ExpressionExecutor for RoundFunctionExecutor {
+    fn execute(&self, event: Option<&dyn ComplexEvent>) -> Option<AttributeValue> {
+        let val = self.value_executor.execute(event)?;
+        match val {
+            AttributeValue::Null => Some(AttributeValue::Null),
+            _ => {
+                let num = to_f64(&val)?;
+                Some(AttributeValue::Double(num.round()))
+            }
+        }
+    }
+
+    fn get_return_type(&self) -> ApiAttributeType {
+        ApiAttributeType::DOUBLE
+    }
+
+    fn clone_executor(&self, ctx: &Arc<SiddhiAppContext>) -> Box<dyn ExpressionExecutor> {
+        Box::new(RoundFunctionExecutor {
+            value_executor: self.value_executor.clone_executor(ctx),
+        })
+    }
+}

--- a/siddhi_rust/src/core/executor/function/mod.rs
+++ b/siddhi_rust/src/core/executor/function/mod.rs
@@ -5,6 +5,10 @@ pub mod if_then_else_function_executor;
 pub mod instance_of_checkers;
 pub mod uuid_function_executor;
 pub mod scalar_function_executor; // Added
+pub mod cast_function_executor;
+pub mod string_functions;
+pub mod date_functions;
+pub mod math_functions;
 
 // pub mod function_executor_base; // If a base struct for stateful functions is created later
 
@@ -13,6 +17,10 @@ pub use self::if_then_else_function_executor::IfThenElseFunctionExecutor;
 pub use self::instance_of_checkers::*;
 pub use self::uuid_function_executor::UuidFunctionExecutor;
 pub use self::scalar_function_executor::ScalarFunctionExecutor; // Added
+pub use self::cast_function_executor::CastFunctionExecutor;
+pub use self::string_functions::{ConcatFunctionExecutor, LengthFunctionExecutor};
+pub use self::date_functions::{CurrentTimestampFunctionExecutor, FormatDateFunctionExecutor};
+pub use self::math_functions::{RoundFunctionExecutor, SqrtFunctionExecutor};
 
 // Other function executors to be added here:
 // pub mod cast_function_executor;

--- a/siddhi_rust/src/core/executor/function/string_functions.rs
+++ b/siddhi_rust/src/core/executor/function/string_functions.rs
@@ -1,0 +1,88 @@
+// siddhi_rust/src/core/executor/function/string_functions.rs
+use crate::core::executor::expression_executor::ExpressionExecutor;
+use crate::core::event::complex_event::ComplexEvent;
+use crate::core::event::value::AttributeValue;
+use crate::query_api::definition::attribute::Type as ApiAttributeType;
+use crate::core::config::siddhi_app_context::SiddhiAppContext;
+use std::sync::Arc;
+
+#[derive(Debug)]
+pub struct LengthFunctionExecutor {
+    expr: Box<dyn ExpressionExecutor>,
+}
+
+impl LengthFunctionExecutor {
+    pub fn new(expr: Box<dyn ExpressionExecutor>) -> Result<Self, String> {
+        if expr.get_return_type() != ApiAttributeType::STRING {
+            return Err("length() requires a STRING argument".to_string());
+        }
+        Ok(Self { expr })
+    }
+}
+
+impl ExpressionExecutor for LengthFunctionExecutor {
+    fn execute(&self, event: Option<&dyn ComplexEvent>) -> Option<AttributeValue> {
+        match self.expr.execute(event)? {
+            AttributeValue::String(s) => Some(AttributeValue::Int(s.len() as i32)),
+            AttributeValue::Null => Some(AttributeValue::Null),
+            _ => None,
+        }
+    }
+
+    fn get_return_type(&self) -> ApiAttributeType {
+        ApiAttributeType::INT
+    }
+
+    fn clone_executor(&self, ctx: &Arc<SiddhiAppContext>) -> Box<dyn ExpressionExecutor> {
+        Box::new(LengthFunctionExecutor {
+            expr: self.expr.clone_executor(ctx),
+        })
+    }
+}
+
+#[derive(Debug)]
+pub struct ConcatFunctionExecutor {
+    executors: Vec<Box<dyn ExpressionExecutor>>,
+}
+
+impl ConcatFunctionExecutor {
+    pub fn new(executors: Vec<Box<dyn ExpressionExecutor>>) -> Result<Self, String> {
+        if executors.is_empty() {
+            return Err("concat() requires at least one argument".to_string());
+        }
+        for e in &executors {
+            if e.get_return_type() != ApiAttributeType::STRING {
+                return Err("concat() arguments must be STRING".to_string());
+            }
+        }
+        Ok(Self { executors })
+    }
+}
+
+impl ExpressionExecutor for ConcatFunctionExecutor {
+    fn execute(&self, event: Option<&dyn ComplexEvent>) -> Option<AttributeValue> {
+        let mut result = String::new();
+        for e in &self.executors {
+            match e.execute(event)? {
+                AttributeValue::String(s) => result.push_str(&s),
+                AttributeValue::Null => return Some(AttributeValue::Null),
+                _ => return None,
+            }
+        }
+        Some(AttributeValue::String(result))
+    }
+
+    fn get_return_type(&self) -> ApiAttributeType {
+        ApiAttributeType::STRING
+    }
+
+    fn clone_executor(&self, ctx: &Arc<SiddhiAppContext>) -> Box<dyn ExpressionExecutor> {
+        Box::new(ConcatFunctionExecutor {
+            executors: self
+                .executors
+                .iter()
+                .map(|e| e.clone_executor(ctx))
+                .collect(),
+        })
+    }
+}


### PR DESCRIPTION
## Summary
- implement `CastFunctionExecutor` to allow type casting
- add string helpers (`length`, `concat`)
- support date functions (`currentTimestamp`, `formatDate`)
- provide math helpers (`sqrt`, `round`)
- expose new executors in `function::mod`
- pull in `chrono` crate for date handling

## Testing
- `cargo test --manifest-path siddhi_rust/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_6844250c61108325bf1b929d5b96476e