### PR TITLE
Add parser support for more built-in functions

### DIFF
--- a/siddhi_rust/src/core/util/parser/expression_parser.rs
+++ b/siddhi_rust/src/core/util/parser/expression_parser.rs
@@ -307,6 +307,53 @@ pub fn parse_expression<'a>( // Added lifetime 'a
                 (None | Some(""), name) if name == "instanceOfLong" && arg_execs.len() == 1 => Ok(Box::new(InstanceOfLongExpressionExecutor::new(arg_execs.remove(0)).map_err(|e| format!("{} at {} in query '{}'", e, loc, context.query_name))?)),
                 (None | Some(""), name) if name == "instanceOfFloat" && arg_execs.len() == 1 => Ok(Box::new(InstanceOfFloatExpressionExecutor::new(arg_execs.remove(0)).map_err(|e| format!("{} at {} in query '{}'", e, loc, context.query_name))?)),
                 (None | Some(""), name) if name == "instanceOfDouble" && arg_execs.len() == 1 => Ok(Box::new(InstanceOfDoubleExpressionExecutor::new(arg_execs.remove(0)).map_err(|e| format!("{} at {} in query '{}'", e, loc, context.query_name))?)),
+                (None | Some(""), "cast") => {
+                    if arg_execs.len() == 2 {
+                        let type_exec = arg_execs.remove(1);
+                        let val_exec = arg_execs.remove(0);
+                        Ok(Box::new(CastFunctionExecutor::new(val_exec, type_exec).map_err(|e| format!("{} at {} in query '{}'", e, loc, context.query_name))?))
+                    } else {
+                        Err(format!("cast expects 2 arguments, found {}", arg_execs.len()))
+                    }
+                }
+                (None | Some(""), "concat") => Ok(Box::new(ConcatFunctionExecutor::new(arg_execs).map_err(|e| format!("{} at {} in query '{}'", e, loc, context.query_name))?)),
+                (None | Some(""), "length") => {
+                    if arg_execs.len() == 1 {
+                        Ok(Box::new(LengthFunctionExecutor::new(arg_execs.remove(0)).map_err(|e| format!("{} at {} in query '{}'", e, loc, context.query_name))?))
+                    } else {
+                        Err(format!("length expects 1 argument, found {}", arg_execs.len()))
+                    }
+                }
+                (None | Some(""), "currentTimestamp") => {
+                    if !arg_execs.is_empty() {
+                        Err(format!("currentTimestamp() takes no arguments, found {}", arg_execs.len()))
+                    } else {
+                        Ok(Box::new(CurrentTimestampFunctionExecutor::default()))
+                    }
+                }
+                (None | Some(""), "formatDate") => {
+                    if arg_execs.len() == 2 {
+                        let pattern_exec = arg_execs.remove(1);
+                        let ts_exec = arg_execs.remove(0);
+                        Ok(Box::new(FormatDateFunctionExecutor::new(ts_exec, pattern_exec).map_err(|e| format!("{} at {} in query '{}'", e, loc, context.query_name))?))
+                    } else {
+                        Err(format!("formatDate expects 2 arguments, found {}", arg_execs.len()))
+                    }
+                }
+                (None | Some(""), "round") => {
+                    if arg_execs.len() == 1 {
+                        Ok(Box::new(RoundFunctionExecutor::new(arg_execs.remove(0)).map_err(|e| format!("{} at {} in query '{}'", e, loc, context.query_name))?))
+                    } else {
+                        Err(format!("round expects 1 argument, found {}", arg_execs.len()))
+                    }
+                }
+                (None | Some(""), "sqrt") => {
+                    if arg_execs.len() == 1 {
+                        Ok(Box::new(SqrtFunctionExecutor::new(arg_execs.remove(0)).map_err(|e| format!("{} at {} in query '{}'", e, loc, context.query_name))?))
+                    } else {
+                        Err(format!("sqrt expects 1 argument, found {}", arg_execs.len()))
+                    }
+                }
                 _ => { // UDF lookup from context
                     if let Some(scalar_fn_factory) = context.siddhi_app_context.get_siddhi_context().get_scalar_function_factory(&function_lookup_name) {
                         Ok(Box::new(

--- a/siddhi_rust/tests/builtin_function_parsing.rs
+++ b/siddhi_rust/tests/builtin_function_parsing.rs
@@ -1,0 +1,113 @@
+use siddhi_rust::core::util::parser::{parse_expression, ExpressionParserContext};
+use siddhi_rust::query_api::expression::Expression;
+use siddhi_rust::core::config::siddhi_app_context::SiddhiAppContext;
+use siddhi_rust::core::config::siddhi_context::SiddhiContext;
+use siddhi_rust::query_api::siddhi_app::SiddhiApp;
+use siddhi_rust::core::event::value::AttributeValue;
+use siddhi_rust::query_api::definition::attribute::Type as AttrType;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+fn make_app_ctx() -> Arc<SiddhiAppContext> {
+    Arc::new(SiddhiAppContext::new(
+        Arc::new(SiddhiContext::default()),
+        "test".to_string(),
+        Arc::new(SiddhiApp::new("app".to_string())),
+        String::new(),
+    ))
+}
+
+fn empty_ctx(query: &str) -> ExpressionParserContext {
+    ExpressionParserContext {
+        siddhi_app_context: make_app_ctx(),
+        stream_meta_map: HashMap::new(),
+        default_source: "dummy".to_string(),
+        query_name: query,
+    }
+}
+
+#[test]
+fn test_cast_function() {
+    let ctx = empty_ctx("cast");
+    let expr = Expression::function_no_ns(
+        "cast".to_string(),
+        vec![
+            Expression::value_int(5),
+            Expression::value_string("string".to_string()),
+        ],
+    );
+    let exec = parse_expression(&expr, &ctx).expect("parse failed");
+    assert_eq!(exec.get_return_type(), AttrType::STRING);
+    let result = exec.execute(None);
+    assert_eq!(result, Some(AttributeValue::String("5".to_string())));
+}
+
+#[test]
+fn test_concat_and_length_functions() {
+    let ctx = empty_ctx("concat_len");
+    let concat_expr = Expression::function_no_ns(
+        "concat".to_string(),
+        vec![
+            Expression::value_string("ab".to_string()),
+            Expression::value_string("cd".to_string()),
+        ],
+    );
+    let concat_exec = parse_expression(&concat_expr, &ctx).unwrap();
+    let concat_res = concat_exec.execute(None);
+    assert_eq!(concat_res, Some(AttributeValue::String("abcd".to_string())));
+
+    let len_expr = Expression::function_no_ns(
+        "length".to_string(),
+        vec![Expression::value_string("hello".to_string())],
+    );
+    let len_exec = parse_expression(&len_expr, &ctx).unwrap();
+    let len_res = len_exec.execute(None);
+    assert_eq!(len_res, Some(AttributeValue::Int(5)));
+}
+
+#[test]
+fn test_current_timestamp_function() {
+    let ctx = empty_ctx("current_ts");
+    let expr = Expression::function_no_ns("currentTimestamp".to_string(), vec![]);
+    let exec = parse_expression(&expr, &ctx).unwrap();
+    assert_eq!(exec.get_return_type(), AttrType::LONG);
+    let val = exec.execute(None);
+    match val {
+        Some(AttributeValue::Long(_)) => {}
+        _ => panic!("expected long"),
+    }
+}
+
+#[test]
+fn test_format_date_function() {
+    let ctx = empty_ctx("format_date");
+    let expr = Expression::function_no_ns(
+        "formatDate".to_string(),
+        vec![
+            Expression::value_long(0),
+            Expression::value_string("%Y".to_string()),
+        ],
+    );
+    let exec = parse_expression(&expr, &ctx).unwrap();
+    let result = exec.execute(None);
+    assert_eq!(result, Some(AttributeValue::String("1970".to_string())));
+}
+
+#[test]
+fn test_round_and_sqrt_functions() {
+    let ctx = empty_ctx("math");
+    let round_expr = Expression::function_no_ns(
+        "round".to_string(),
+        vec![Expression::value_double(3.7)],
+    );
+    let round_exec = parse_expression(&round_expr, &ctx).unwrap();
+    assert_eq!(round_exec.execute(None), Some(AttributeValue::Double(4.0)));
+
+    let sqrt_expr = Expression::function_no_ns(
+        "sqrt".to_string(),
+        vec![Expression::value_int(16)],
+    );
+    let sqrt_exec = parse_expression(&sqrt_expr, &ctx).unwrap();
+    assert_eq!(sqrt_exec.execute(None), Some(AttributeValue::Double(4.0)));
+}
+


### PR DESCRIPTION
## Summary
- extend attribute function parsing to recognize `cast`, `concat`, `length`,
  `currentTimestamp`, `formatDate`, `round`, and `sqrt`
- add unit tests covering these built-in functions

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68443cee1b908325aa9a221195415205