### PR TITLE
Add extensible window processing support

### DIFF
--- a/siddhi_rust/src/core/query/processor/stream/mod.rs
+++ b/siddhi_rust/src/core/query/processor/stream/mod.rs
@@ -1,10 +1,11 @@
 // siddhi_rust/src/core/query/processor/stream/mod.rs
 pub mod filter;
+pub mod window; // Window processors like length, time
 // pub mod single; // If SingleStreamProcessor becomes a struct/module later
-// pub mod window; // For window processors
 // pub mod function; // For stream function processors
 
 pub use self::filter::FilterProcessor;
+pub use self::window::{LengthWindowProcessor, TimeWindowProcessor};
 // Other StreamProcessor types would be re-exported here.
 
 // AbstractStreamProcessor.java and StreamProcessor.java (interface-like abstract class) from Java

--- a/siddhi_rust/src/core/query/processor/stream/window/mod.rs
+++ b/siddhi_rust/src/core/query/processor/stream/window/mod.rs
@@ -1,0 +1,157 @@
+use crate::core::config::{siddhi_app_context::SiddhiAppContext, siddhi_query_context::SiddhiQueryContext};
+use crate::core::event::complex_event::ComplexEvent;
+use crate::core::query::processor::{CommonProcessorMeta, ProcessingMode, Processor};
+use crate::query_api::execution::query::input::handler::WindowHandler;
+use crate::query_api::expression::{self, constant::ConstantValueWithFloat, Expression};
+use std::sync::{Arc, Mutex};
+
+pub trait WindowProcessor: Processor {}
+
+#[derive(Debug)]
+pub struct LengthWindowProcessor {
+    meta: CommonProcessorMeta,
+    pub length: usize,
+}
+
+impl LengthWindowProcessor {
+    pub fn new(length: usize, app_ctx: Arc<SiddhiAppContext>, query_ctx: Arc<SiddhiQueryContext>) -> Self {
+        Self { meta: CommonProcessorMeta::new(app_ctx, query_ctx), length }
+    }
+
+    pub fn from_handler(
+        handler: &WindowHandler,
+        app_ctx: Arc<SiddhiAppContext>,
+        query_ctx: Arc<SiddhiQueryContext>,
+    ) -> Result<Self, String> {
+        let expr = handler
+            .get_parameters()
+            .first()
+            .ok_or("Length window requires a parameter")?;
+        if let Expression::Constant(c) = expr {
+            let len = match &c.value {
+                ConstantValueWithFloat::Int(i) => *i as usize,
+                ConstantValueWithFloat::Long(l) => *l as usize,
+                _ => {
+                    return Err("Length window size must be int or long".to_string())
+                }
+            };
+            Ok(Self::new(len, app_ctx, query_ctx))
+        } else {
+            Err("Length window size must be constant".to_string())
+        }
+    }
+}
+
+impl Processor for LengthWindowProcessor {
+    fn process(&self, complex_event_chunk: Option<Box<dyn ComplexEvent>>) {
+        if let Some(ref next) = self.meta.next_processor {
+            next.lock().unwrap().process(complex_event_chunk);
+        }
+    }
+
+    fn next_processor(&self) -> Option<Arc<Mutex<dyn Processor>>> {
+        self.meta.next_processor.as_ref().map(Arc::clone)
+    }
+
+    fn set_next_processor(&mut self, next: Option<Arc<Mutex<dyn Processor>>>) {
+        self.meta.next_processor = next;
+    }
+
+    fn clone_processor(&self, query_ctx: &Arc<SiddhiQueryContext>) -> Box<dyn Processor> {
+        Box::new(Self::new(self.length, Arc::clone(&self.meta.siddhi_app_context), Arc::clone(query_ctx)))
+    }
+
+    fn get_siddhi_app_context(&self) -> Arc<SiddhiAppContext> {
+        Arc::clone(&self.meta.siddhi_app_context)
+    }
+
+    fn get_processing_mode(&self) -> ProcessingMode { ProcessingMode::SLIDE }
+
+    fn is_stateful(&self) -> bool { true }
+}
+
+impl WindowProcessor for LengthWindowProcessor {}
+
+#[derive(Debug)]
+pub struct TimeWindowProcessor {
+    meta: CommonProcessorMeta,
+    pub duration_ms: i64,
+}
+
+impl TimeWindowProcessor {
+    pub fn new(duration_ms: i64, app_ctx: Arc<SiddhiAppContext>, query_ctx: Arc<SiddhiQueryContext>) -> Self {
+        Self { meta: CommonProcessorMeta::new(app_ctx, query_ctx), duration_ms }
+    }
+
+    pub fn from_handler(
+        handler: &WindowHandler,
+        app_ctx: Arc<SiddhiAppContext>,
+        query_ctx: Arc<SiddhiQueryContext>,
+    ) -> Result<Self, String> {
+        let expr = handler
+            .get_parameters()
+            .first()
+            .ok_or("Time window requires a parameter")?;
+        if let Expression::Constant(c) = expr {
+            let dur = match &c.value {
+                ConstantValueWithFloat::Time(t) => *t,
+                ConstantValueWithFloat::Long(l) => *l,
+                _ => return Err("Time window duration must be time constant".to_string()),
+            };
+            Ok(Self::new(dur, app_ctx, query_ctx))
+        } else {
+            Err("Time window duration must be constant".to_string())
+        }
+    }
+}
+
+impl Processor for TimeWindowProcessor {
+    fn process(&self, complex_event_chunk: Option<Box<dyn ComplexEvent>>) {
+        if let Some(ref next) = self.meta.next_processor {
+            next.lock().unwrap().process(complex_event_chunk);
+        }
+    }
+
+    fn next_processor(&self) -> Option<Arc<Mutex<dyn Processor>>> {
+        self.meta.next_processor.as_ref().map(Arc::clone)
+    }
+
+    fn set_next_processor(&mut self, next: Option<Arc<Mutex<dyn Processor>>>) {
+        self.meta.next_processor = next;
+    }
+
+    fn clone_processor(&self, query_ctx: &Arc<SiddhiQueryContext>) -> Box<dyn Processor> {
+        Box::new(Self::new(self.duration_ms, Arc::clone(&self.meta.siddhi_app_context), Arc::clone(query_ctx)))
+    }
+
+    fn get_siddhi_app_context(&self) -> Arc<SiddhiAppContext> {
+        Arc::clone(&self.meta.siddhi_app_context)
+    }
+
+    fn get_processing_mode(&self) -> ProcessingMode { ProcessingMode::SLIDE }
+
+    fn is_stateful(&self) -> bool { true }
+}
+
+impl WindowProcessor for TimeWindowProcessor {}
+
+pub fn create_window_processor(
+    handler: &WindowHandler,
+    app_ctx: Arc<SiddhiAppContext>,
+    query_ctx: Arc<SiddhiQueryContext>,
+) -> Result<Arc<Mutex<dyn Processor>>, String> {
+    match handler.name.as_str() {
+        "length" => Ok(Arc::new(Mutex::new(LengthWindowProcessor::from_handler(
+            handler,
+            app_ctx,
+            query_ctx,
+        )?))),
+        "time" => Ok(Arc::new(Mutex::new(TimeWindowProcessor::from_handler(
+            handler,
+            app_ctx,
+            query_ctx,
+        )?))),
+        other => Err(format!("Unsupported window type '{}'", other)),
+    }
+}
+

--- a/siddhi_rust/src/core/siddhi_app_runtime_builder.rs
+++ b/siddhi_rust/src/core/siddhi_app_runtime_builder.rs
@@ -3,6 +3,7 @@ use crate::core::config::siddhi_app_context::SiddhiAppContext;
 use crate::core::stream::stream_junction::StreamJunction;
 use crate::core::query::query_runtime::QueryRuntime;
 use crate::core::siddhi_app_runtime::SiddhiAppRuntime; // Actual SiddhiAppRuntime
+use crate::core::window::WindowRuntime;
 use crate::query_api::siddhi_app::SiddhiApp as ApiSiddhiApp; // For build() method arg
 use crate::query_api::definition::StreamDefinition as ApiStreamDefinition; // Added this import
 
@@ -11,7 +12,6 @@ use std::sync::{Arc, Mutex};
 
 // Placeholders for runtime components until they are defined
 #[derive(Debug, Clone, Default)] pub struct TableRuntimePlaceholder {}
-#[derive(Debug, Clone, Default)] pub struct WindowRuntimePlaceholder {}
 #[derive(Debug, Clone, Default)] pub struct AggregationRuntimePlaceholder {}
 #[derive(Debug, Clone, Default)] pub struct TriggerRuntimePlaceholder {}
 #[derive(Debug, Clone, Default)] pub struct PartitionRuntimePlaceholder {}
@@ -28,7 +28,7 @@ pub struct SiddhiAppRuntimeBuilder {
 
     pub stream_junction_map: HashMap<String, Arc<Mutex<StreamJunction>>>,
     pub table_map: HashMap<String, Arc<Mutex<TableRuntimePlaceholder>>>,
-    pub window_map: HashMap<String, Arc<Mutex<WindowRuntimePlaceholder>>>,
+    pub window_map: HashMap<String, Arc<Mutex<crate::core::window::WindowRuntime>>>,
     pub aggregation_map: HashMap<String, Arc<Mutex<AggregationRuntimePlaceholder>>>,
 
     pub query_runtimes: Vec<Arc<QueryRuntime>>,
@@ -76,7 +76,7 @@ impl SiddhiAppRuntimeBuilder {
     pub fn add_table(&mut self, table_id: String, table_runtime: Arc<Mutex<TableRuntimePlaceholder>>) {
         self.table_map.insert(table_id, table_runtime);
     }
-     pub fn add_window(&mut self, window_id: String, window_runtime: Arc<Mutex<WindowRuntimePlaceholder>>) {
+    pub fn add_window(&mut self, window_id: String, window_runtime: Arc<Mutex<crate::core::window::WindowRuntime>>) {
         self.window_map.insert(window_id, window_runtime);
     }
     pub fn add_aggregation_runtime(&mut self, agg_id: String, agg_runtime: Arc<Mutex<AggregationRuntimePlaceholder>>) {

--- a/siddhi_rust/src/core/util/parser/siddhi_app_parser.rs
+++ b/siddhi_rust/src/core/util/parser/siddhi_app_parser.rs
@@ -12,6 +12,7 @@ use crate::query_api::{
 use crate::core::config::siddhi_app_context::SiddhiAppContext;
 use crate::core::config::siddhi_query_context::SiddhiQueryContext; // QueryParser will need this
 use crate::core::siddhi_app_runtime_builder::SiddhiAppRuntimeBuilder;
+use crate::core::window::WindowRuntime;
 use crate::core::stream::stream_junction::{StreamJunction, OnErrorAction}; // For creating junctions
 use crate::query_api::execution::query::input::stream::input_stream::InputStreamTrait;
 // use super::query_parser::QueryParser; // To be created or defined in this file for now
@@ -98,14 +99,14 @@ impl SiddhiAppParser {
             builder.add_stream_junction(stream_id.clone(), stream_junction);
         }
 
-        // TODO: Define TableDefinitions, WindowDefinitions, AggregationDefinitions
-        // This involves creating TableRuntime, WindowRuntime, AggregationRuntime instances
-        // and adding them to the builder. Example:
-        // for (table_id, table_def) in &api_siddhi_app.table_definition_map {
-        //     builder.add_table_definition(table_def.clone());
-        //     let table_runtime = TableParser::parse_table(table_def, &siddhi_app_context, &builder.stream_junction_map);
-        //     builder.add_table(table_id.clone(), table_runtime);
-        // }
+        // TableDefinitions, WindowDefinitions, AggregationDefinitions
+        for (window_id, window_def) in &api_siddhi_app.window_definition_map {
+            builder.add_window_definition(Arc::clone(window_def));
+            builder.add_window(
+                window_id.clone(),
+                Arc::new(Mutex::new(WindowRuntime::new(Arc::clone(window_def)))),
+            );
+        }
 
         // TODO: Initialize Windows after all tables/windows are defined (as in Java)
 

--- a/siddhi_rust/src/core/window/mod.rs
+++ b/siddhi_rust/src/core/window/mod.rs
@@ -1,0 +1,7 @@
+// siddhi_rust/src/core/window/mod.rs
+
+//! Window related runtime structures.
+
+pub mod window_runtime;
+
+pub use window_runtime::WindowRuntime;

--- a/siddhi_rust/src/core/window/window_runtime.rs
+++ b/siddhi_rust/src/core/window/window_runtime.rs
@@ -1,0 +1,26 @@
+// siddhi_rust/src/core/window/window_runtime.rs
+
+use crate::core::query::processor::Processor;
+use crate::query_api::definition::WindowDefinition;
+use std::sync::{Arc, Mutex};
+
+/// Minimal runtime representation of a window.
+#[derive(Debug)]
+pub struct WindowRuntime {
+    pub definition: Arc<WindowDefinition>,
+    pub processor: Option<Arc<Mutex<dyn Processor>>>,
+}
+
+impl WindowRuntime {
+    pub fn new(definition: Arc<WindowDefinition>) -> Self {
+        Self {
+            definition,
+            processor: None,
+        }
+    }
+
+    pub fn set_processor(&mut self, processor: Arc<Mutex<dyn Processor>>) {
+        self.processor = Some(processor);
+    }
+}
+

--- a/siddhi_rust/tests/window_queries.rs
+++ b/siddhi_rust/tests/window_queries.rs
@@ -1,0 +1,62 @@
+use siddhi_rust::core::util::parser::QueryParser;
+use siddhi_rust::core::config::{siddhi_app_context::SiddhiAppContext, siddhi_context::SiddhiContext};
+use siddhi_rust::core::stream::stream_junction::StreamJunction;
+use siddhi_rust::query_api::execution::query::Query;
+use siddhi_rust::query_api::execution::query::input::stream::single_input_stream::SingleInputStream;
+use siddhi_rust::query_api::execution::query::input::stream::input_stream::InputStream;
+use siddhi_rust::query_api::execution::query::selection::Selector;
+use siddhi_rust::query_api::execution::query::output::output_stream::{OutputStream, OutputStreamAction, InsertIntoStreamAction};
+use siddhi_rust::query_api::definition::StreamDefinition;
+use siddhi_rust::query_api::definition::attribute::Type as AttrType;
+use siddhi_rust::query_api::expression::Expression;
+use std::sync::{Arc, Mutex};
+use std::collections::HashMap;
+
+fn setup_context() -> (Arc<SiddhiAppContext>, HashMap<String, Arc<Mutex<StreamJunction>>>) {
+    let siddhi_context = Arc::new(SiddhiContext::new());
+    let app = Arc::new(siddhi_rust::query_api::siddhi_app::SiddhiApp::new("TestApp".to_string()));
+    let app_ctx = Arc::new(SiddhiAppContext::new(Arc::clone(&siddhi_context), "TestApp".to_string(), Arc::clone(&app), String::new()));
+
+    let in_def = Arc::new(StreamDefinition::new("InputStream".to_string()).attribute("val".to_string(), AttrType::INT));
+    let out_def = Arc::new(StreamDefinition::new("OutStream".to_string()).attribute("val".to_string(), AttrType::INT));
+
+    let in_junction = Arc::new(Mutex::new(StreamJunction::new("InputStream".to_string(), Arc::clone(&in_def), Arc::clone(&app_ctx), 1024, false)));
+    let out_junction = Arc::new(Mutex::new(StreamJunction::new("OutStream".to_string(), Arc::clone(&out_def), Arc::clone(&app_ctx), 1024, false)));
+
+    let mut map = HashMap::new();
+    map.insert("InputStream".to_string(), in_junction);
+    map.insert("OutStream".to_string(), out_junction);
+
+    (app_ctx, map)
+}
+
+#[test]
+fn test_length_window_query_parse() {
+    let (app_ctx, junctions) = setup_context();
+    let si = SingleInputStream::new_basic("InputStream".to_string(), false, false, None, Vec::new())
+        .window(None, "length".to_string(), vec![Expression::value_int(5)]);
+    let input = InputStream::Single(si);
+    let selector = Selector::new();
+    let insert_action = InsertIntoStreamAction { target_id: "OutStream".to_string(), is_inner_stream: false, is_fault_stream: false };
+    let out_stream = OutputStream::new(OutputStreamAction::InsertInto(insert_action), None);
+    let query = Query::query().from(input).select(selector).out_stream(out_stream);
+
+    let res = QueryParser::parse_query(&query, &app_ctx, &junctions);
+    assert!(res.is_ok());
+}
+
+#[test]
+fn test_time_window_query_parse() {
+    let (app_ctx, junctions) = setup_context();
+    let si = SingleInputStream::new_basic("InputStream".to_string(), false, false, None, Vec::new())
+        .window(None, "time".to_string(), vec![Expression::time_sec(1)]);
+    let input = InputStream::Single(si);
+    let selector = Selector::new();
+    let insert_action = InsertIntoStreamAction { target_id: "OutStream".to_string(), is_inner_stream: false, is_fault_stream: false };
+    let out_stream = OutputStream::new(OutputStreamAction::InsertInto(insert_action), None);
+    let query = Query::query().from(input).select(selector).out_stream(out_stream);
+
+    let res = QueryParser::parse_query(&query, &app_ctx, &junctions);
+    assert!(res.is_ok());
+}
+


### PR DESCRIPTION
## Summary
- move window parameter validation into each processor
- expose helper to build window processors
- implement simple `WindowRuntime`
- register windows with real runtime objects
- update query parser to use new helper

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_684450315b0c83258002143e5a46aa23