### PR TITLE
Add basic in-memory table operations

### DIFF
--- a/siddhi_rust/src/core/query/output/delete_table_processor.rs
+++ b/siddhi_rust/src/core/query/output/delete_table_processor.rs
@@ -1,0 +1,39 @@
+use crate::core::config::siddhi_app_context::SiddhiAppContext;
+use crate::core::config::siddhi_query_context::SiddhiQueryContext;
+use crate::core::event::complex_event::ComplexEvent;
+use crate::core::query::processor::{Processor, CommonProcessorMeta, ProcessingMode};
+use crate::core::table::Table;
+use std::sync::{Arc, Mutex};
+
+#[derive(Debug)]
+pub struct DeleteTableProcessor {
+    meta: CommonProcessorMeta,
+    table: Arc<dyn Table>,
+}
+
+impl DeleteTableProcessor {
+    pub fn new(table: Arc<dyn Table>, app_ctx: Arc<SiddhiAppContext>, query_ctx: Arc<SiddhiQueryContext>) -> Self {
+        Self { meta: CommonProcessorMeta::new(app_ctx, query_ctx), table }
+    }
+}
+
+impl Processor for DeleteTableProcessor {
+    fn process(&self, mut chunk: Option<Box<dyn ComplexEvent>>) {
+        while let Some(mut event) = chunk {
+            let next = event.set_next(None);
+            if let Some(data) = event.get_output_data() {
+                self.table.delete(data);
+            }
+            chunk = next;
+        }
+    }
+
+    fn next_processor(&self) -> Option<Arc<Mutex<dyn Processor>>> { None }
+    fn set_next_processor(&mut self, _next: Option<Arc<Mutex<dyn Processor>>>) {}
+    fn clone_processor(&self, query_ctx: &Arc<SiddhiQueryContext>) -> Box<dyn Processor> {
+        Box::new(Self::new(Arc::clone(&self.table), Arc::clone(&self.meta.siddhi_app_context), Arc::clone(query_ctx)))
+    }
+    fn get_siddhi_app_context(&self) -> Arc<SiddhiAppContext> { Arc::clone(&self.meta.siddhi_app_context) }
+    fn get_processing_mode(&self) -> ProcessingMode { ProcessingMode::DEFAULT }
+    fn is_stateful(&self) -> bool { false }
+}

--- a/siddhi_rust/src/core/query/output/insert_into_table_processor.rs
+++ b/siddhi_rust/src/core/query/output/insert_into_table_processor.rs
@@ -1,0 +1,39 @@
+use crate::core::config::siddhi_app_context::SiddhiAppContext;
+use crate::core::config::siddhi_query_context::SiddhiQueryContext;
+use crate::core::event::complex_event::ComplexEvent;
+use crate::core::query::processor::{Processor, CommonProcessorMeta, ProcessingMode};
+use crate::core::table::Table;
+use std::sync::{Arc, Mutex};
+
+#[derive(Debug)]
+pub struct InsertIntoTableProcessor {
+    meta: CommonProcessorMeta,
+    table: Arc<dyn Table>,
+}
+
+impl InsertIntoTableProcessor {
+    pub fn new(table: Arc<dyn Table>, app_ctx: Arc<SiddhiAppContext>, query_ctx: Arc<SiddhiQueryContext>) -> Self {
+        Self { meta: CommonProcessorMeta::new(app_ctx, query_ctx), table }
+    }
+}
+
+impl Processor for InsertIntoTableProcessor {
+    fn process(&self, mut chunk: Option<Box<dyn ComplexEvent>>) {
+        while let Some(mut event) = chunk {
+            let next = event.set_next(None);
+            if let Some(data) = event.get_output_data() {
+                self.table.insert(data);
+            }
+            chunk = next;
+        }
+    }
+
+    fn next_processor(&self) -> Option<Arc<Mutex<dyn Processor>>> { None }
+    fn set_next_processor(&mut self, _next: Option<Arc<Mutex<dyn Processor>>>) {}
+    fn clone_processor(&self, query_ctx: &Arc<SiddhiQueryContext>) -> Box<dyn Processor> {
+        Box::new(Self::new(Arc::clone(&self.table), Arc::clone(&self.meta.siddhi_app_context), Arc::clone(query_ctx)))
+    }
+    fn get_siddhi_app_context(&self) -> Arc<SiddhiAppContext> { Arc::clone(&self.meta.siddhi_app_context) }
+    fn get_processing_mode(&self) -> ProcessingMode { ProcessingMode::DEFAULT }
+    fn is_stateful(&self) -> bool { false }
+}

--- a/siddhi_rust/src/core/query/output/mod.rs
+++ b/siddhi_rust/src/core/query/output/mod.rs
@@ -5,8 +5,9 @@
 // and rate limiters that operate on core event chunks.
 
 pub mod insert_into_stream_processor;
-// pub mod delete_stream_processor; // For DELETE operations
-// pub mod update_stream_processor; // For UPDATE operations
+pub mod insert_into_table_processor;
+pub mod update_table_processor;
+pub mod delete_table_processor;
 // pub mod update_or_insert_stream_processor; // For UPDATE OR INSERT
 // pub mod output_rate_limiter; // Core engine's rate limiter
 pub mod callback_processor; // Added
@@ -15,4 +16,7 @@ pub mod callback_processor; // Added
 // Query-specific output callbacks (QueryCallback in Java) might also go here or a sub-module.
 
 pub use self::insert_into_stream_processor::InsertIntoStreamProcessor;
+pub use self::insert_into_table_processor::InsertIntoTableProcessor;
+pub use self::update_table_processor::UpdateTableProcessor;
+pub use self::delete_table_processor::DeleteTableProcessor;
 pub use self::callback_processor::CallbackProcessor; // Added

--- a/siddhi_rust/src/core/query/output/update_table_processor.rs
+++ b/siddhi_rust/src/core/query/output/update_table_processor.rs
@@ -1,0 +1,43 @@
+use crate::core::config::siddhi_app_context::SiddhiAppContext;
+use crate::core::config::siddhi_query_context::SiddhiQueryContext;
+use crate::core::event::complex_event::ComplexEvent;
+use crate::core::event::stream::stream_event::StreamEvent;
+use crate::core::query::processor::{Processor, CommonProcessorMeta, ProcessingMode};
+use crate::core::table::Table;
+use std::sync::{Arc, Mutex};
+
+#[derive(Debug)]
+pub struct UpdateTableProcessor {
+    meta: CommonProcessorMeta,
+    table: Arc<dyn Table>,
+}
+
+impl UpdateTableProcessor {
+    pub fn new(table: Arc<dyn Table>, app_ctx: Arc<SiddhiAppContext>, query_ctx: Arc<SiddhiQueryContext>) -> Self {
+        Self { meta: CommonProcessorMeta::new(app_ctx, query_ctx), table }
+    }
+}
+
+impl Processor for UpdateTableProcessor {
+    fn process(&self, mut chunk: Option<Box<dyn ComplexEvent>>) {
+        while let Some(mut event) = chunk {
+            let next = event.set_next(None);
+            if let Some(se) = event.as_any().downcast_ref::<StreamEvent>() {
+                let old = se.before_window_data.clone();
+                if let Some(new) = se.get_output_data() {
+                    self.table.update(&old, new);
+                }
+            }
+            chunk = next;
+        }
+    }
+
+    fn next_processor(&self) -> Option<Arc<Mutex<dyn Processor>>> { None }
+    fn set_next_processor(&mut self, _next: Option<Arc<Mutex<dyn Processor>>>) {}
+    fn clone_processor(&self, query_ctx: &Arc<SiddhiQueryContext>) -> Box<dyn Processor> {
+        Box::new(Self::new(Arc::clone(&self.table), Arc::clone(&self.meta.siddhi_app_context), Arc::clone(query_ctx)))
+    }
+    fn get_siddhi_app_context(&self) -> Arc<SiddhiAppContext> { Arc::clone(&self.meta.siddhi_app_context) }
+    fn get_processing_mode(&self) -> ProcessingMode { ProcessingMode::DEFAULT }
+    fn is_stateful(&self) -> bool { true }
+}

--- a/siddhi_rust/src/core/stream/input/table_input_handler.rs
+++ b/siddhi_rust/src/core/stream/input/table_input_handler.rs
@@ -1,19 +1,31 @@
 use crate::core::config::siddhi_app_context::SiddhiAppContext;
 use crate::core::event::event::Event;
+use crate::core::event::value::AttributeValue;
+use crate::core::table::Table;
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
 pub struct TableInputHandler {
     pub siddhi_app_context: Arc<SiddhiAppContext>,
-    // placeholder for table reference
+    table: Arc<dyn Table>,
 }
 
 impl TableInputHandler {
-    pub fn new(siddhi_app_context: Arc<SiddhiAppContext>) -> Self {
-        Self { siddhi_app_context }
+    pub fn new(table: Arc<dyn Table>, siddhi_app_context: Arc<SiddhiAppContext>) -> Self {
+        Self { siddhi_app_context, table }
     }
 
-    pub fn add(&self, _events: Vec<Event>) {
-        // placeholder
+    pub fn add(&self, events: Vec<Event>) {
+        for event in events {
+            self.table.insert(&event.data);
+        }
+    }
+
+    pub fn update(&self, old: Vec<AttributeValue>, new: Vec<AttributeValue>) -> bool {
+        self.table.update(&old, &new)
+    }
+
+    pub fn delete(&self, values: Vec<AttributeValue>) -> bool {
+        self.table.delete(&values)
     }
 }

--- a/siddhi_rust/src/core/util/parser/siddhi_app_parser.rs
+++ b/siddhi_rust/src/core/util/parser/siddhi_app_parser.rs
@@ -120,6 +120,7 @@ impl SiddhiAppParser {
                         api_query,
                         &siddhi_app_context,
                         &builder.stream_junction_map,
+                        &builder.table_definition_map,
                     )?;
                     builder.add_query_runtime(Arc::new(query_runtime));
                     // TODO: siddhi_app_context.addEternalReferencedHolder(queryRuntime);

--- a/siddhi_rust/tests/builtin_function_parsing.rs
+++ b/siddhi_rust/tests/builtin_function_parsing.rs
@@ -21,6 +21,7 @@ fn empty_ctx(query: &str) -> ExpressionParserContext {
     ExpressionParserContext {
         siddhi_app_context: make_app_ctx(),
         stream_meta_map: HashMap::new(),
+        table_meta_map: HashMap::new(),
         default_source: "dummy".to_string(),
         query_name: query,
     }

--- a/siddhi_rust/tests/expression_parser_complex.rs
+++ b/siddhi_rust/tests/expression_parser_complex.rs
@@ -35,6 +35,7 @@ fn test_parse_expression_multi_stream_variable() {
     let ctx = ExpressionParserContext {
         siddhi_app_context: make_app_ctx(),
         stream_meta_map: map,
+        table_meta_map: HashMap::new(),
         default_source: "A".to_string(),
         query_name: "Q1",
     };
@@ -52,6 +53,7 @@ fn test_compare_type_coercion_int_double() {
     let ctx = ExpressionParserContext {
         siddhi_app_context: make_app_ctx(),
         stream_meta_map: HashMap::new(),
+        table_meta_map: HashMap::new(),
         default_source: "dummy".to_string(),
         query_name: "Q2",
     };
@@ -77,6 +79,7 @@ fn test_variable_not_found_error() {
     let ctx = ExpressionParserContext {
         siddhi_app_context: make_app_ctx(),
         stream_meta_map: map,
+        table_meta_map: HashMap::new(),
         default_source: "A".to_string(),
         query_name: "Q3",
     };

--- a/siddhi_rust/tests/stateful_udf.rs
+++ b/siddhi_rust/tests/stateful_udf.rs
@@ -86,6 +86,7 @@ fn parser_ctx(manager: &SiddhiManager) -> ExpressionParserContext<'static> {
     ExpressionParserContext {
         siddhi_app_context: app_ctx,
         stream_meta_map: HashMap::new(),
+        table_meta_map: HashMap::new(),
         default_source: "default".to_string(),
         query_name: "q",
     }

--- a/siddhi_rust/tests/table_ops.rs
+++ b/siddhi_rust/tests/table_ops.rs
@@ -1,0 +1,45 @@
+use siddhi_rust::core::table::{InMemoryTable, Table};
+use siddhi_rust::core::stream::input::table_input_handler::TableInputHandler;
+use siddhi_rust::core::event::event::Event;
+use siddhi_rust::core::event::stream::stream_event::StreamEvent;
+use siddhi_rust::core::query::output::InsertIntoTableProcessor;
+use siddhi_rust::core::query::processor::Processor;
+use siddhi_rust::core::event::complex_event::ComplexEvent;
+use siddhi_rust::core::config::siddhi_app_context::SiddhiAppContext;
+use siddhi_rust::core::config::siddhi_query_context::SiddhiQueryContext;
+use siddhi_rust::core::config::siddhi_context::SiddhiContext;
+use siddhi_rust::core::event::value::AttributeValue;
+use std::sync::Arc;
+
+#[test]
+fn test_table_input_handler_add() {
+    let ctx = Arc::new(SiddhiAppContext::new(
+        Arc::new(SiddhiContext::default()),
+        "app".to_string(),
+        Arc::new(siddhi_rust::query_api::siddhi_app::SiddhiApp::new("app".to_string())),
+        String::new(),
+    ));
+    let table: Arc<dyn Table> = Arc::new(InMemoryTable::new());
+    ctx.get_siddhi_context().add_table("T1".to_string(), table.clone());
+    let handler = TableInputHandler::new(table, Arc::clone(&ctx));
+    handler.add(vec![Event::new_with_data(0, vec![AttributeValue::Int(5)])]);
+    assert!(ctx.get_siddhi_context().get_table("T1").unwrap().contains(&[AttributeValue::Int(5)]));
+}
+
+#[test]
+fn test_insert_into_table_processor() {
+    let app_ctx = Arc::new(SiddhiAppContext::new(
+        Arc::new(SiddhiContext::default()),
+        "app".to_string(),
+        Arc::new(siddhi_rust::query_api::siddhi_app::SiddhiApp::new("app".to_string())),
+        String::new(),
+    ));
+    let table: Arc<dyn Table> = Arc::new(InMemoryTable::new());
+    app_ctx.get_siddhi_context().add_table("T2".to_string(), table.clone());
+    let query_ctx = Arc::new(SiddhiQueryContext::new(Arc::clone(&app_ctx), "q".to_string(), None));
+    let proc = InsertIntoTableProcessor::new(table, Arc::clone(&app_ctx), Arc::clone(&query_ctx));
+    let mut se = StreamEvent::new(0, 0, 0, 1);
+    se.set_output_data(Some(vec![AttributeValue::Int(7)]));
+    proc.process(Some(Box::new(se)));
+    assert!(app_ctx.get_siddhi_context().get_table("T2").unwrap().contains(&[AttributeValue::Int(7)]));
+}

--- a/siddhi_rust/tests/window_queries.rs
+++ b/siddhi_rust/tests/window_queries.rs
@@ -41,7 +41,7 @@ fn test_length_window_query_parse() {
     let out_stream = OutputStream::new(OutputStreamAction::InsertInto(insert_action), None);
     let query = Query::query().from(input).select(selector).out_stream(out_stream);
 
-    let res = QueryParser::parse_query(&query, &app_ctx, &junctions);
+    let res = QueryParser::parse_query(&query, &app_ctx, &junctions, &HashMap::new());
     assert!(res.is_ok());
 }
 
@@ -56,7 +56,7 @@ fn test_time_window_query_parse() {
     let out_stream = OutputStream::new(OutputStreamAction::InsertInto(insert_action), None);
     let query = Query::query().from(input).select(selector).out_stream(out_stream);
 
-    let res = QueryParser::parse_query(&query, &app_ctx, &junctions);
+    let res = QueryParser::parse_query(&query, &app_ctx, &junctions, &HashMap::new());
     assert!(res.is_ok());
 }
 


### PR DESCRIPTION
## Summary
- implement `TableInputHandler` with insert/update/delete functionality
- add table insert/update/delete processors
- extend `ExpressionParser` and `QueryParser` to be aware of tables
- expose new table processors in query output module
- update tests for new parser context field
- add table operation unit tests

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68459a70464c8325a21f3f9a53260cd4