### PR TITLE
Add basic attribute aggregators

### DIFF
--- a/siddhi_rust/README.md
+++ b/siddhi_rust/README.md
@@ -42,7 +42,7 @@ This port is **far from feature-complete** with the Java version. Users should b
     *   **Windows**: No window processors (`TimeWindow`, `LengthWindow`, etc.) are ported. This is a major feature set.
     *   **Joins**: No join processors or join logic implemented.
     *   **Patterns & Sequences**: No pattern or sequence processors implemented.
-    *   **Aggregations**: No aggregation runtime or aggregator functions ported.
+    *   **Aggregations**: Basic attribute aggregator executors (sum, avg, count, distinctCount, min/max and forever variants) are implemented for use in queries.
 *   **State Management & Persistence**:
     *   **Tables**: An `InMemoryTable` implementation supports insert, update, delete and membership checks.
     *   **Persistence**: `SnapshotService` and `PersistenceStore` framework is not implemented. No state persistence or recovery.

--- a/siddhi_rust/src/core/executor/expression_executor.rs
+++ b/siddhi_rust/src/core/executor/expression_executor.rs
@@ -5,6 +5,7 @@ use crate::core::event::complex_event::ComplexEvent; // The ComplexEvent trait
 use crate::core::event::value::AttributeValue; // The enum for actual data values
 use crate::query_api::definition::attribute::Type as ApiAttributeType; // Import Type enum
 use std::fmt::Debug;
+use std::any::Any;
 // use std::sync::Arc; // Not needed for trait definition itself
 
 // ExpressionExecutor is an interface in Java. In Rust, it's a trait.
@@ -29,6 +30,17 @@ pub trait ExpressionExecutor: Debug + Send + Sync + 'static {
     // but the interface should be consistent.
     // Child executors (if any) would be cloned recursively using their own clone_executor methods.
     fn clone_executor(&self, siddhi_app_context: &Arc<SiddhiAppContext>) -> Box<dyn ExpressionExecutor>;
+
+    fn as_any(&self) -> &dyn Any
+    where
+        Self: Sized + 'static,
+    {
+        self
+    }
+
+    fn is_attribute_aggregator(&self) -> bool {
+        false
+    }
 }
 
 // To allow `Box<dyn ExpressionExecutor>` to be `Clone`.

--- a/siddhi_rust/src/core/query/selector/attribute/aggregator/mod.rs
+++ b/siddhi_rust/src/core/query/selector/attribute/aggregator/mod.rs
@@ -1,0 +1,346 @@
+use std::sync::Mutex;
+use std::collections::{HashMap};
+use std::sync::Arc;
+
+use crate::core::event::complex_event::{ComplexEvent, ComplexEventType};
+use crate::core::event::value::AttributeValue;
+use crate::core::executor::expression_executor::ExpressionExecutor;
+use crate::core::query::processor::ProcessingMode;
+use crate::core::config::siddhi_query_context::SiddhiQueryContext;
+use crate::core::config::siddhi_app_context::SiddhiAppContext;
+use crate::query_api::definition::attribute::Type as ApiAttributeType;
+
+pub trait AttributeAggregatorExecutor: ExpressionExecutor {
+    fn init(
+        &mut self,
+        executors: Vec<Box<dyn ExpressionExecutor>>,
+        processing_mode: ProcessingMode,
+        expired_output: bool,
+        ctx: &SiddhiQueryContext,
+    ) -> Result<(), String>;
+
+    fn process_add(&self, data: Option<AttributeValue>) -> Option<AttributeValue>;
+    fn process_remove(&self, data: Option<AttributeValue>) -> Option<AttributeValue>;
+    fn reset(&self) -> Option<AttributeValue>;
+    fn clone_box(&self) -> Box<dyn AttributeAggregatorExecutor>;
+}
+
+impl Clone for Box<dyn AttributeAggregatorExecutor> {
+    fn clone(&self) -> Self {
+        self.clone_box()
+    }
+}
+
+fn value_as_f64(v: &AttributeValue) -> Option<f64> {
+    match v {
+        AttributeValue::Int(i) => Some(*i as f64),
+        AttributeValue::Long(l) => Some(*l as f64),
+        AttributeValue::Float(f) => Some(*f as f64),
+        AttributeValue::Double(d) => Some(*d),
+        _ => None,
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+struct SumState {
+    sum: f64,
+    count: u64,
+}
+
+#[derive(Debug)]
+pub struct SumAttributeAggregatorExecutor {
+    arg_exec: Option<Box<dyn ExpressionExecutor>>,
+    return_type: ApiAttributeType,
+    state: Mutex<SumState>,
+    app_ctx: Option<Arc<SiddhiAppContext>>,
+}
+
+impl Default for SumAttributeAggregatorExecutor {
+    fn default() -> Self {
+        Self { arg_exec: None, return_type: ApiAttributeType::DOUBLE, state: Mutex::new(SumState::default()), app_ctx: None }
+    }
+}
+
+impl AttributeAggregatorExecutor for SumAttributeAggregatorExecutor {
+    fn init(
+        &mut self,
+        mut executors: Vec<Box<dyn ExpressionExecutor>>,
+        _mode: ProcessingMode,
+        _expired_output: bool,
+        ctx: &SiddhiQueryContext,
+    ) -> Result<(), String> {
+        if executors.len() != 1 {
+            return Err("sum() requires exactly one argument".to_string());
+        }
+        let exec = executors.remove(0);
+        let rtype = match exec.get_return_type() {
+            ApiAttributeType::INT | ApiAttributeType::LONG => ApiAttributeType::LONG,
+            ApiAttributeType::FLOAT | ApiAttributeType::DOUBLE => ApiAttributeType::DOUBLE,
+            t => return Err(format!("sum not supported for {:?}", t)),
+        };
+        self.return_type = rtype;
+        self.arg_exec = Some(exec);
+        self.app_ctx = Some(Arc::clone(&ctx.siddhi_app_context));
+        Ok(())
+    }
+
+    fn process_add(&self, data: Option<AttributeValue>) -> Option<AttributeValue> {
+        if let Some(v) = data.as_ref().and_then(|v| value_as_f64(v)) {
+            let mut st = self.state.lock().unwrap();
+            st.sum += v;
+            st.count += 1;
+        }
+        let st = self.state.lock().unwrap();
+        match self.return_type {
+            ApiAttributeType::LONG => Some(AttributeValue::Long(st.sum as i64)),
+            ApiAttributeType::DOUBLE => Some(AttributeValue::Double(st.sum)),
+            _ => None,
+        }
+    }
+
+    fn process_remove(&self, data: Option<AttributeValue>) -> Option<AttributeValue> {
+        if let Some(v) = data.as_ref().and_then(|v| value_as_f64(v)) {
+            let mut st = self.state.lock().unwrap();
+            st.sum -= v;
+            if st.count > 0 { st.count -= 1; }
+        }
+        let st = self.state.lock().unwrap();
+        match self.return_type {
+            ApiAttributeType::LONG => Some(AttributeValue::Long(st.sum as i64)),
+            ApiAttributeType::DOUBLE => Some(AttributeValue::Double(st.sum)),
+            _ => None,
+        }
+    }
+
+    fn reset(&self) -> Option<AttributeValue> {
+        let mut st = self.state.lock().unwrap();
+        st.sum = 0.0;
+        st.count = 0;
+        None
+    }
+
+    fn clone_box(&self) -> Box<dyn AttributeAggregatorExecutor> {
+        let ctx = self.app_ctx.as_ref().unwrap();
+        Box::new(SumAttributeAggregatorExecutor {
+            arg_exec: self.arg_exec.as_ref().map(|e| e.clone_executor(ctx)),
+            return_type: self.return_type,
+            state: Mutex::new(self.state.lock().unwrap().clone()),
+            app_ctx: Some(Arc::clone(ctx)),
+        })
+    }
+}
+
+impl ExpressionExecutor for SumAttributeAggregatorExecutor {
+    fn execute(&self, event: Option<&dyn ComplexEvent>) -> Option<AttributeValue> {
+        let event = event?;
+        let data = self.arg_exec.as_ref().and_then(|e| e.execute(Some(event)));
+        match event.get_event_type() {
+            ComplexEventType::Current => self.process_add(data),
+            ComplexEventType::Expired => self.process_remove(data),
+            ComplexEventType::Reset => self.reset(),
+            _ => None,
+        }
+    }
+
+    fn get_return_type(&self) -> ApiAttributeType { self.return_type }
+
+    fn clone_executor(&self, _ctx: &Arc<SiddhiAppContext>) -> Box<dyn ExpressionExecutor> {
+        self.clone_box()
+    }
+
+    fn is_attribute_aggregator(&self) -> bool { true }
+}
+
+#[derive(Debug, Clone, Default)]
+struct AvgState { sum: f64, count: u64 }
+
+#[derive(Debug)]
+pub struct AvgAttributeAggregatorExecutor {
+    arg_exec: Option<Box<dyn ExpressionExecutor>>,
+    state: Mutex<AvgState>,
+    app_ctx: Option<Arc<SiddhiAppContext>>,
+}
+
+impl Default for AvgAttributeAggregatorExecutor {
+    fn default() -> Self { Self { arg_exec: None, state: Mutex::new(AvgState::default()), app_ctx: None } }
+}
+
+impl AttributeAggregatorExecutor for AvgAttributeAggregatorExecutor {
+    fn init(&mut self, mut execs: Vec<Box<dyn ExpressionExecutor>>, _m: ProcessingMode, _e: bool, ctx: &SiddhiQueryContext) -> Result<(), String> {
+        if execs.len() != 1 { return Err("avg() requires one argument".to_string()); }
+        self.arg_exec = Some(execs.remove(0));
+        self.app_ctx = Some(Arc::clone(&ctx.siddhi_app_context));
+        Ok(())
+    }
+
+    fn process_add(&self, data: Option<AttributeValue>) -> Option<AttributeValue> {
+        if let Some(v) = data.as_ref().and_then(|v| value_as_f64(v)) {
+            let mut st = self.state.lock().unwrap();
+            st.sum += v;
+            st.count += 1;
+        }
+        let st = self.state.lock().unwrap();
+        if st.count == 0 { None } else { Some(AttributeValue::Double(st.sum / st.count as f64)) }
+    }
+
+    fn process_remove(&self, data: Option<AttributeValue>) -> Option<AttributeValue> {
+        if let Some(v) = data.as_ref().and_then(|v| value_as_f64(v)) {
+            let mut st = self.state.lock().unwrap();
+            st.sum -= v;
+            if st.count > 0 { st.count -= 1; }
+        }
+        let st = self.state.lock().unwrap();
+        if st.count == 0 { None } else { Some(AttributeValue::Double(st.sum / st.count as f64)) }
+    }
+
+    fn reset(&self) -> Option<AttributeValue> {
+        let mut st = self.state.lock().unwrap();
+        st.sum = 0.0; st.count = 0; None
+    }
+
+    fn clone_box(&self) -> Box<dyn AttributeAggregatorExecutor> {
+        let ctx = self.app_ctx.as_ref().unwrap();
+        Box::new(AvgAttributeAggregatorExecutor { arg_exec: self.arg_exec.as_ref().map(|e| e.clone_executor(ctx)), state: Mutex::new(self.state.lock().unwrap().clone()), app_ctx: Some(Arc::clone(ctx)) })
+    }
+}
+
+impl ExpressionExecutor for AvgAttributeAggregatorExecutor {
+    fn execute(&self, event: Option<&dyn ComplexEvent>) -> Option<AttributeValue> {
+        let event = event?;
+        let data = self.arg_exec.as_ref().and_then(|e| e.execute(Some(event)));
+        match event.get_event_type() {
+            ComplexEventType::Current => self.process_add(data),
+            ComplexEventType::Expired => self.process_remove(data),
+            ComplexEventType::Reset => self.reset(),
+            _ => None,
+        }
+    }
+
+    fn get_return_type(&self) -> ApiAttributeType { ApiAttributeType::DOUBLE }
+
+    fn clone_executor(&self, _ctx: &Arc<SiddhiAppContext>) -> Box<dyn ExpressionExecutor> { self.clone_box() }
+
+    fn is_attribute_aggregator(&self) -> bool { true }
+}
+
+#[derive(Debug, Clone, Default)]
+struct CountState { count: i64 }
+
+#[derive(Debug)]
+pub struct CountAttributeAggregatorExecutor {
+    state: Mutex<CountState>,
+    app_ctx: Option<Arc<SiddhiAppContext>>,
+}
+
+impl Default for CountAttributeAggregatorExecutor { fn default() -> Self { Self { state: Mutex::new(CountState::default()), app_ctx: None } } }
+
+impl AttributeAggregatorExecutor for CountAttributeAggregatorExecutor {
+    fn init(&mut self, _e: Vec<Box<dyn ExpressionExecutor>>, _m: ProcessingMode, _ex: bool, ctx: &SiddhiQueryContext) -> Result<(), String> { self.app_ctx = Some(Arc::clone(&ctx.siddhi_app_context)); Ok(()) }
+
+    fn process_add(&self, _d: Option<AttributeValue>) -> Option<AttributeValue> { let mut st=self.state.lock().unwrap(); st.count+=1; Some(AttributeValue::Long(st.count)) }
+    fn process_remove(&self, _d: Option<AttributeValue>) -> Option<AttributeValue> { let mut st=self.state.lock().unwrap(); st.count-=1; Some(AttributeValue::Long(st.count)) }
+    fn reset(&self) -> Option<AttributeValue> { self.state.lock().unwrap().count=0; Some(AttributeValue::Long(0)) }
+    fn clone_box(&self) -> Box<dyn AttributeAggregatorExecutor> { Box::new(CountAttributeAggregatorExecutor { state: Mutex::new(self.state.lock().unwrap().clone()), app_ctx: self.app_ctx.as_ref().cloned() }) }
+}
+
+impl ExpressionExecutor for CountAttributeAggregatorExecutor {
+    fn execute(&self, event: Option<&dyn ComplexEvent>) -> Option<AttributeValue> {
+        let event = event?;
+        match event.get_event_type() {
+            ComplexEventType::Current => self.process_add(None),
+            ComplexEventType::Expired => self.process_remove(None),
+            ComplexEventType::Reset => self.reset(),
+            _ => None,
+        }
+    }
+
+    fn get_return_type(&self) -> ApiAttributeType { ApiAttributeType::LONG }
+
+    fn clone_executor(&self, _ctx: &Arc<SiddhiAppContext>) -> Box<dyn ExpressionExecutor> { self.clone_box() }
+
+    fn is_attribute_aggregator(&self) -> bool { true }
+}
+
+#[derive(Debug, Clone, Default)]
+struct DistinctCountState { map: HashMap<String,i64> }
+
+#[derive(Debug)]
+pub struct DistinctCountAttributeAggregatorExecutor {
+    arg_exec: Option<Box<dyn ExpressionExecutor>>,
+    state: Mutex<DistinctCountState>,
+    app_ctx: Option<Arc<SiddhiAppContext>>,
+}
+
+impl Default for DistinctCountAttributeAggregatorExecutor { fn default() -> Self { Self { arg_exec: None, state: Mutex::new(DistinctCountState::default()), app_ctx: None } } }
+
+impl AttributeAggregatorExecutor for DistinctCountAttributeAggregatorExecutor {
+    fn init(&mut self, mut e: Vec<Box<dyn ExpressionExecutor>>, _m: ProcessingMode, _ex: bool, ctx: &SiddhiQueryContext) -> Result<(), String> {
+        if e.len()!=1 { return Err("distinctCount() requires one arg".to_string()); }
+        self.arg_exec=Some(e.remove(0));
+        self.app_ctx=Some(Arc::clone(&ctx.siddhi_app_context));
+        Ok(())
+    }
+    fn process_add(&self, data: Option<AttributeValue>) -> Option<AttributeValue> {
+        if let Some(v)=data { let key=format!("{:?}",v); let mut st=self.state.lock().unwrap(); let c=st.map.entry(key).or_insert(0); *c+=1; }
+        Some(AttributeValue::Long(self.state.lock().unwrap().map.len() as i64))
+    }
+    fn process_remove(&self, data: Option<AttributeValue>) -> Option<AttributeValue> {
+        if let Some(v)=data { let key=format!("{:?}",v); let mut st=self.state.lock().unwrap(); if let Some(c)=st.map.get_mut(&key){ *c-=1; if *c<=0{ st.map.remove(&key); } } }
+        Some(AttributeValue::Long(self.state.lock().unwrap().map.len() as i64))
+    }
+    fn reset(&self) -> Option<AttributeValue> { self.state.lock().unwrap().map.clear(); Some(AttributeValue::Long(0)) }
+    fn clone_box(&self) -> Box<dyn AttributeAggregatorExecutor> { let ctx=self.app_ctx.as_ref().unwrap(); Box::new(DistinctCountAttributeAggregatorExecutor { arg_exec:self.arg_exec.as_ref().map(|e| e.clone_executor(ctx)), state: Mutex::new(self.state.lock().unwrap().clone()), app_ctx:Some(Arc::clone(ctx)) }) }
+}
+
+impl ExpressionExecutor for DistinctCountAttributeAggregatorExecutor {
+    fn execute(&self, event: Option<&dyn ComplexEvent>) -> Option<AttributeValue> {
+        let event=event?; let data=self.arg_exec.as_ref().and_then(|e| e.execute(Some(event)));
+        match event.get_event_type() {
+            ComplexEventType::Current=>self.process_add(data),
+            ComplexEventType::Expired=>self.process_remove(data),
+            ComplexEventType::Reset=>self.reset(),
+            _=>None,
+        }
+    }
+    fn get_return_type(&self) -> ApiAttributeType { ApiAttributeType::LONG }
+    fn clone_executor(&self, _ctx:&Arc<SiddhiAppContext>) -> Box<dyn ExpressionExecutor> { self.clone_box() }
+    fn is_attribute_aggregator(&self) -> bool { true }
+}
+
+#[derive(Debug, Clone, Default)]
+struct MinMaxState { value: Option<f64> }
+
+macro_rules! minmax_exec {
+    ($name:ident, $cmp:expr) => {
+        #[derive(Debug)]
+        pub struct $name {
+            arg_exec: Option<Box<dyn ExpressionExecutor>>,
+            return_type: ApiAttributeType,
+            state: Mutex<MinMaxState>,
+            app_ctx: Option<Arc<SiddhiAppContext>>,
+        }
+        impl Default for $name { fn default() -> Self { Self { arg_exec: None, return_type: ApiAttributeType::DOUBLE, state: Mutex::new(MinMaxState::default()), app_ctx: None } } }
+        impl AttributeAggregatorExecutor for $name {
+            fn init(&mut self, mut e: Vec<Box<dyn ExpressionExecutor>>, _m:ProcessingMode,_ex:bool, ctx:&SiddhiQueryContext)->Result<(),String>{ if e.len()!=1 {return Err("aggregator requires one arg".into());} let exec=e.remove(0); self.return_type=exec.get_return_type(); self.arg_exec=Some(exec); self.app_ctx=Some(Arc::clone(&ctx.siddhi_app_context)); Ok(()) }
+            fn process_add(&self,data:Option<AttributeValue>)->Option<AttributeValue>{ if let Some(v)=data.and_then(|v| value_as_f64(&v)) { let mut st=self.state.lock().unwrap(); match st.value { Some(current) => if $cmp(v,current) { st.value=Some(v); }, None => st.value=Some(v) } } st_to_val(self.return_type, &self.state.lock().unwrap()) }
+            fn process_remove(&self,_data:Option<AttributeValue>)->Option<AttributeValue>{ st_to_val(self.return_type, &self.state.lock().unwrap()) }
+            fn reset(&self)->Option<AttributeValue>{ self.state.lock().unwrap().value=None; None }
+            fn clone_box(&self)->Box<dyn AttributeAggregatorExecutor>{ let ctx=self.app_ctx.as_ref().unwrap(); Box::new($name { arg_exec:self.arg_exec.as_ref().map(|e| e.clone_executor(ctx)), return_type:self.return_type, state: Mutex::new(self.state.lock().unwrap().clone()), app_ctx:Some(Arc::clone(ctx)) }) }
+        }
+        impl ExpressionExecutor for $name {
+            fn execute(&self,event:Option<&dyn ComplexEvent>)->Option<AttributeValue>{ let event=event?; let data=self.arg_exec.as_ref().and_then(|e| e.execute(Some(event))); match event.get_event_type(){ ComplexEventType::Current=>self.process_add(data), ComplexEventType::Expired=>self.process_remove(data), ComplexEventType::Reset=>self.reset(), _=>None } }
+            fn get_return_type(&self)->ApiAttributeType{ self.return_type }
+            fn clone_executor(&self,_ctx:&Arc<SiddhiAppContext>)->Box<dyn ExpressionExecutor>{ self.clone_box() }
+            fn is_attribute_aggregator(&self)->bool{ true }
+        }
+    };
+}
+
+fn st_to_val(rt: ApiAttributeType, st: &MinMaxState) -> Option<AttributeValue> {
+    st.value.map(|v| match rt { ApiAttributeType::INT => AttributeValue::Int(v as i32), ApiAttributeType::LONG => AttributeValue::Long(v as i64), ApiAttributeType::FLOAT => AttributeValue::Float(v as f32), _ => AttributeValue::Double(v) })
+}
+
+minmax_exec!(MinAttributeAggregatorExecutor, |v,current| v<current);
+minmax_exec!(MaxAttributeAggregatorExecutor, |v,current| v>current);
+minmax_exec!(MinForeverAttributeAggregatorExecutor, |v,current| v<current);
+minmax_exec!(MaxForeverAttributeAggregatorExecutor, |v,current| v>current);

--- a/siddhi_rust/src/core/query/selector/attribute/mod.rs
+++ b/siddhi_rust/src/core/query/selector/attribute/mod.rs
@@ -1,6 +1,8 @@
 // siddhi_rust/src/core/query/selector/attribute/mod.rs
 pub mod output_attribute_processor;
+pub mod aggregator;
 pub use self::output_attribute_processor::OutputAttributeProcessor;
+pub use self::aggregator::*;
 
 // aggregator/ and processor/ sub-packages from Java would be modules here if their contents are ported.
 // pub mod aggregator;

--- a/siddhi_rust/src/core/query/selector/attribute/output_attribute_processor.rs
+++ b/siddhi_rust/src/core/query/selector/attribute/output_attribute_processor.rs
@@ -51,9 +51,7 @@ impl OutputAttributeProcessor {
     }
 
     /// Whether this attribute processor involves an aggregator function.
-    /// The current simplified runtime has no aggregator implementations,
-    /// so this always returns `false`.
     pub fn is_aggregator(&self) -> bool {
-        false
+        self.expression_executor.is_attribute_aggregator()
     }
 }

--- a/siddhi_rust/src/core/util/parser/expression_parser.rs
+++ b/siddhi_rust/src/core/util/parser/expression_parser.rs
@@ -18,8 +18,11 @@ use crate::core::executor::{
 };
 use crate::core::event::value::AttributeValue as CoreAttributeValue;
 use crate::core::config::siddhi_app_context::SiddhiAppContext;
+use crate::core::query::selector::attribute::aggregator::*;
+use crate::core::config::siddhi_query_context::SiddhiQueryContext;
 use crate::core::event::stream::meta_stream_event::MetaStreamEvent;
 use crate::core::executor::function::scalar_function_executor::ScalarFunctionExecutor;
+use crate::core::query::processor::ProcessingMode;
 
 
 use std::sync::Arc;
@@ -98,6 +101,7 @@ impl Drop for AttributeFunctionExpressionExecutor {
 /// entry should be used when a variable does not explicitly specify a source.
 pub struct ExpressionParserContext<'a> {
     pub siddhi_app_context: Arc<SiddhiAppContext>,
+    pub siddhi_query_context: Arc<SiddhiQueryContext>,
     pub stream_meta_map: HashMap<String, Arc<MetaStreamEvent>>,
     pub table_meta_map: HashMap<String, Arc<MetaStreamEvent>>,
     pub default_source: String,
@@ -353,6 +357,46 @@ pub fn parse_expression<'a>( // Added lifetime 'a
                     } else {
                         Err(format!("sqrt expects 1 argument, found {}", arg_execs.len()))
                     }
+                }
+                (None | Some(""), "sum") => {
+                    let mut exec = SumAttributeAggregatorExecutor::default();
+                    exec.init(arg_execs, ProcessingMode::BATCH, false, &context.siddhi_query_context)?;
+                    Ok(Box::new(exec))
+                }
+                (None | Some(""), "avg") => {
+                    let mut exec = AvgAttributeAggregatorExecutor::default();
+                    exec.init(arg_execs, ProcessingMode::BATCH, false, &context.siddhi_query_context)?;
+                    Ok(Box::new(exec))
+                }
+                (None | Some(""), "count") => {
+                    let mut exec = CountAttributeAggregatorExecutor::default();
+                    exec.init(arg_execs, ProcessingMode::BATCH, false, &context.siddhi_query_context)?;
+                    Ok(Box::new(exec))
+                }
+                (None | Some(""), "distinctCount") => {
+                    let mut exec = DistinctCountAttributeAggregatorExecutor::default();
+                    exec.init(arg_execs, ProcessingMode::BATCH, false, &context.siddhi_query_context)?;
+                    Ok(Box::new(exec))
+                }
+                (None | Some(""), "min") => {
+                    let mut exec = MinAttributeAggregatorExecutor::default();
+                    exec.init(arg_execs, ProcessingMode::BATCH, false, &context.siddhi_query_context)?;
+                    Ok(Box::new(exec))
+                }
+                (None | Some(""), "max") => {
+                    let mut exec = MaxAttributeAggregatorExecutor::default();
+                    exec.init(arg_execs, ProcessingMode::BATCH, false, &context.siddhi_query_context)?;
+                    Ok(Box::new(exec))
+                }
+                (None | Some(""), "minForever") => {
+                    let mut exec = MinForeverAttributeAggregatorExecutor::default();
+                    exec.init(arg_execs, ProcessingMode::BATCH, false, &context.siddhi_query_context)?;
+                    Ok(Box::new(exec))
+                }
+                (None | Some(""), "maxForever") => {
+                    let mut exec = MaxForeverAttributeAggregatorExecutor::default();
+                    exec.init(arg_execs, ProcessingMode::BATCH, false, &context.siddhi_query_context)?;
+                    Ok(Box::new(exec))
                 }
                 _ => { // UDF lookup from context
                     if let Some(scalar_fn_factory) = context.siddhi_app_context.get_siddhi_context().get_scalar_function_factory(&function_lookup_name) {

--- a/siddhi_rust/src/core/util/parser/query_parser.rs
+++ b/siddhi_rust/src/core/util/parser/query_parser.rs
@@ -89,6 +89,7 @@ impl QueryParser {
                 }
                 let ctx = ExpressionParserContext {
                     siddhi_app_context: Arc::clone(siddhi_app_context),
+                    siddhi_query_context: Arc::clone(&siddhi_query_context),
                     stream_meta_map,
                     table_meta_map,
                     default_source: input_stream_id.clone(),
@@ -150,6 +151,7 @@ impl QueryParser {
                 let cond_exec = if let Some(expr) = &join_stream.on_compare {
                     Some(parse_expression(expr, &ExpressionParserContext {
                         siddhi_app_context: Arc::clone(siddhi_app_context),
+                        siddhi_query_context: Arc::clone(&siddhi_query_context),
                         stream_meta_map: stream_meta_map.clone(),
                         table_meta_map: table_meta_map.clone(),
                         default_source: left_id.clone(),
@@ -182,6 +184,7 @@ impl QueryParser {
 
                 let ctx = ExpressionParserContext {
                     siddhi_app_context: Arc::clone(siddhi_app_context),
+                    siddhi_query_context: Arc::clone(&siddhi_query_context),
                     stream_meta_map,
                     table_meta_map,
                     default_source: left_id.clone(),
@@ -250,6 +253,7 @@ impl QueryParser {
 
                 ExpressionParserContext {
                     siddhi_app_context: Arc::clone(siddhi_app_context),
+                    siddhi_query_context: Arc::clone(&siddhi_query_context),
                     stream_meta_map,
                     table_meta_map,
                     default_source: first_id.clone(),

--- a/siddhi_rust/tests/aggregator_window.rs
+++ b/siddhi_rust/tests/aggregator_window.rs
@@ -1,0 +1,58 @@
+use siddhi_rust::core::util::parser::{parse_expression, ExpressionParserContext};
+use siddhi_rust::core::config::{siddhi_app_context::SiddhiAppContext, siddhi_context::SiddhiContext, siddhi_query_context::SiddhiQueryContext};
+use siddhi_rust::query_api::siddhi_app::SiddhiApp;
+use siddhi_rust::query_api::expression::{Expression, variable::Variable};
+use siddhi_rust::query_api::definition::{StreamDefinition, attribute::Type as AttrType};
+use siddhi_rust::core::event::stream::meta_stream_event::MetaStreamEvent;
+use siddhi_rust::core::event::stream::stream_event::StreamEvent;
+use siddhi_rust::core::event::complex_event::{ComplexEventType, ComplexEvent};
+use siddhi_rust::core::event::value::AttributeValue;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+fn make_ctx(name: &str) -> ExpressionParserContext<'static> {
+    let app_ctx = Arc::new(SiddhiAppContext::new(
+        Arc::new(SiddhiContext::default()),
+        "app".to_string(),
+        Arc::new(SiddhiApp::new("app".to_string())),
+        String::new(),
+    ));
+    let q_ctx = Arc::new(SiddhiQueryContext::new(Arc::clone(&app_ctx), name.to_string(), None));
+    let stream_def = Arc::new(StreamDefinition::new("s".to_string()).attribute("price".to_string(), AttrType::INT));
+    let meta = MetaStreamEvent::new_for_single_input(Arc::clone(&stream_def));
+    let mut stream_map = HashMap::new();
+    stream_map.insert("s".to_string(), Arc::new(meta));
+    let qn: &'static str = Box::leak(name.to_string().into_boxed_str());
+    ExpressionParserContext {
+        siddhi_app_context: Arc::clone(&app_ctx),
+        siddhi_query_context: q_ctx,
+        stream_meta_map: stream_map,
+        table_meta_map: HashMap::new(),
+        default_source: "s".to_string(),
+        query_name: qn,
+    }
+}
+
+#[test]
+fn test_sum_aggregator() {
+    let ctx = make_ctx("sumq");
+    let expr = Expression::function_no_ns(
+        "sum".to_string(),
+        vec![Expression::Variable(Variable::new("price".to_string()))],
+    );
+    let exec = parse_expression(&expr, &ctx).unwrap();
+    // build events
+    let mut e1 = StreamEvent::new(0,1,0,0);
+    e1.before_window_data[0] = AttributeValue::Int(5);
+    let mut e2 = StreamEvent::new(0,1,0,0);
+    e2.before_window_data[0] = AttributeValue::Int(10);
+
+    assert_eq!(exec.execute(Some(&e1)), Some(AttributeValue::Long(5)));
+    assert_eq!(exec.execute(Some(&e2)), Some(AttributeValue::Long(15)));
+    let mut reset = StreamEvent::new(0,0,0,0);
+    reset.set_event_type(ComplexEventType::Reset);
+    exec.execute(Some(&reset));
+    let mut e3 = StreamEvent::new(0,1,0,0);
+    e3.before_window_data[0] = AttributeValue::Int(4);
+    assert_eq!(exec.execute(Some(&e3)), Some(AttributeValue::Long(4)));
+}

--- a/siddhi_rust/tests/builtin_function_parsing.rs
+++ b/siddhi_rust/tests/builtin_function_parsing.rs
@@ -2,6 +2,7 @@ use siddhi_rust::core::util::parser::{parse_expression, ExpressionParserContext}
 use siddhi_rust::query_api::expression::Expression;
 use siddhi_rust::core::config::siddhi_app_context::SiddhiAppContext;
 use siddhi_rust::core::config::siddhi_context::SiddhiContext;
+use siddhi_rust::core::config::siddhi_query_context::SiddhiQueryContext;
 use siddhi_rust::query_api::siddhi_app::SiddhiApp;
 use siddhi_rust::core::event::value::AttributeValue;
 use siddhi_rust::query_api::definition::attribute::Type as AttrType;
@@ -17,9 +18,14 @@ fn make_app_ctx() -> Arc<SiddhiAppContext> {
     ))
 }
 
+fn make_query_ctx(name: &str) -> Arc<SiddhiQueryContext> {
+    Arc::new(SiddhiQueryContext::new(make_app_ctx(), name.to_string(), None))
+}
+
 fn empty_ctx(query: &str) -> ExpressionParserContext {
     ExpressionParserContext {
         siddhi_app_context: make_app_ctx(),
+        siddhi_query_context: make_query_ctx(query),
         stream_meta_map: HashMap::new(),
         table_meta_map: HashMap::new(),
         default_source: "dummy".to_string(),

--- a/siddhi_rust/tests/expression_parser_complex.rs
+++ b/siddhi_rust/tests/expression_parser_complex.rs
@@ -5,6 +5,7 @@ use siddhi_rust::query_api::definition::{StreamDefinition, attribute::Type as At
 use siddhi_rust::core::event::stream::meta_stream_event::MetaStreamEvent;
 use siddhi_rust::core::config::siddhi_app_context::SiddhiAppContext;
 use siddhi_rust::core::config::siddhi_context::SiddhiContext;
+use siddhi_rust::core::config::siddhi_query_context::SiddhiQueryContext;
 use siddhi_rust::query_api::siddhi_app::SiddhiApp;
 use std::sync::Arc;
 use std::collections::HashMap;
@@ -16,6 +17,10 @@ fn make_app_ctx() -> Arc<SiddhiAppContext> {
         Arc::new(SiddhiApp::new("app".to_string())),
         String::new(),
     ))
+}
+
+fn make_query_ctx(name: &str) -> Arc<SiddhiQueryContext> {
+    Arc::new(SiddhiQueryContext::new(make_app_ctx(), name.to_string(), None))
 }
 
 #[test]
@@ -34,6 +39,7 @@ fn test_parse_expression_multi_stream_variable() {
 
     let ctx = ExpressionParserContext {
         siddhi_app_context: make_app_ctx(),
+        siddhi_query_context: make_query_ctx("Q1"),
         stream_meta_map: map,
         table_meta_map: HashMap::new(),
         default_source: "A".to_string(),
@@ -52,6 +58,7 @@ fn test_parse_expression_multi_stream_variable() {
 fn test_compare_type_coercion_int_double() {
     let ctx = ExpressionParserContext {
         siddhi_app_context: make_app_ctx(),
+        siddhi_query_context: make_query_ctx("Q2"),
         stream_meta_map: HashMap::new(),
         table_meta_map: HashMap::new(),
         default_source: "dummy".to_string(),
@@ -78,6 +85,7 @@ fn test_variable_not_found_error() {
 
     let ctx = ExpressionParserContext {
         siddhi_app_context: make_app_ctx(),
+        siddhi_query_context: make_query_ctx("Q3"),
         stream_meta_map: map,
         table_meta_map: HashMap::new(),
         default_source: "A".to_string(),

--- a/siddhi_rust/tests/stateful_udf.rs
+++ b/siddhi_rust/tests/stateful_udf.rs
@@ -2,6 +2,7 @@ use siddhi_rust::core::siddhi_manager::SiddhiManager;
 use siddhi_rust::core::config::siddhi_app_context::SiddhiAppContext;
 use siddhi_rust::query_api::siddhi_app::SiddhiApp;
 use siddhi_rust::core::util::parser::{parse_expression, ExpressionParserContext};
+use siddhi_rust::core::config::siddhi_query_context::SiddhiQueryContext;
 use siddhi_rust::query_api::expression::Expression;
 use siddhi_rust::core::event::value::AttributeValue;
 use siddhi_rust::query_api::definition::attribute::Type as ApiAttributeType;
@@ -83,8 +84,11 @@ fn parser_ctx(manager: &SiddhiManager) -> ExpressionParserContext<'static> {
         String::new(),
     ));
 
+    let query_ctx = Arc::new(SiddhiQueryContext::new(Arc::clone(&app_ctx), "q".to_string(), None));
+
     ExpressionParserContext {
         siddhi_app_context: app_ctx,
+        siddhi_query_context: query_ctx,
         stream_meta_map: HashMap::new(),
         table_meta_map: HashMap::new(),
         default_source: "default".to_string(),


### PR DESCRIPTION
## Summary
- implement AttributeAggregatorExecutor trait and core aggregators
- wire aggregators into expression parser and output attribute processor
- add aggregator unit tests
- update docs to mention aggregator support

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6846a8f6ea688325bb480104d1c3a7cb