### PR TITLE
Implement extension registry in Siddhi Rust

### DIFF
--- a/siddhi_rust/README.md
+++ b/siddhi_rust/README.md
@@ -99,6 +99,16 @@ let manager = SiddhiManager::new();
 manager.add_scalar_function_factory("counter".to_string(), Box::new(CounterFn));
 ```
 
+Other extension types such as windows and attribute aggregators can also be registered using the `SiddhiManager`.
+
+```rust
+use siddhi_rust::core::extension::{WindowProcessorFactory, AttributeAggregatorFactory};
+
+let manager = SiddhiManager::new();
+// manager.add_window_factory("myWindow".to_string(), Box::new(MyWindowFactory));
+// manager.add_attribute_aggregator_factory("myAgg".to_string(), Box::new(MyAggFactory));
+```
+
 ### Example Usage
 
 ```rust

--- a/siddhi_rust/src/core/extension/mod.rs
+++ b/siddhi_rust/src/core/extension/mod.rs
@@ -1,0 +1,54 @@
+use std::fmt::Debug;
+use std::sync::{Arc, Mutex};
+
+use crate::core::config::{siddhi_app_context::SiddhiAppContext, siddhi_query_context::SiddhiQueryContext};
+use crate::core::executor::expression_executor::ExpressionExecutor;
+use crate::core::query::processor::Processor;
+use crate::core::query::selector::attribute::aggregator::AttributeAggregatorExecutor;
+use crate::query_api::execution::query::input::handler::WindowHandler;
+
+pub trait WindowProcessorFactory: Debug + Send + Sync {
+    fn create(
+        &self,
+        handler: &WindowHandler,
+        app_ctx: Arc<SiddhiAppContext>,
+        query_ctx: Arc<SiddhiQueryContext>,
+    ) -> Result<Arc<Mutex<dyn Processor>>, String>;
+    fn clone_box(&self) -> Box<dyn WindowProcessorFactory>;
+}
+impl Clone for Box<dyn WindowProcessorFactory> {
+    fn clone(&self) -> Self { self.clone_box() }
+}
+
+pub trait AttributeAggregatorFactory: Debug + Send + Sync {
+    fn create(&self) -> Box<dyn AttributeAggregatorExecutor>;
+    fn clone_box(&self) -> Box<dyn AttributeAggregatorFactory>;
+}
+impl Clone for Box<dyn AttributeAggregatorFactory> {
+    fn clone(&self) -> Self { self.clone_box() }
+}
+
+pub trait SourceFactory: Debug + Send + Sync {
+    fn clone_box(&self) -> Box<dyn SourceFactory>;
+}
+impl Clone for Box<dyn SourceFactory> { fn clone(&self) -> Self { self.clone_box() } }
+
+pub trait SinkFactory: Debug + Send + Sync {
+    fn clone_box(&self) -> Box<dyn SinkFactory>;
+}
+impl Clone for Box<dyn SinkFactory> { fn clone(&self) -> Self { self.clone_box() } }
+
+pub trait StoreFactory: Debug + Send + Sync {
+    fn clone_box(&self) -> Box<dyn StoreFactory>;
+}
+impl Clone for Box<dyn StoreFactory> { fn clone(&self) -> Self { self.clone_box() } }
+
+pub trait SourceMapperFactory: Debug + Send + Sync {
+    fn clone_box(&self) -> Box<dyn SourceMapperFactory>;
+}
+impl Clone for Box<dyn SourceMapperFactory> { fn clone(&self) -> Self { self.clone_box() } }
+
+pub trait SinkMapperFactory: Debug + Send + Sync {
+    fn clone_box(&self) -> Box<dyn SinkMapperFactory>;
+}
+impl Clone for Box<dyn SinkMapperFactory> { fn clone(&self) -> Self { self.clone_box() } }

--- a/siddhi_rust/src/core/mod.rs
+++ b/siddhi_rust/src/core/mod.rs
@@ -21,6 +21,7 @@ pub mod trigger;
 pub mod util;
 pub mod window;
 pub mod persistence; // Added
+pub mod extension;
 
 // Re-export key public-facing structs from core
 pub use self::siddhi_app_runtime::SiddhiAppRuntime;

--- a/siddhi_rust/src/core/query/selector/attribute/aggregator/mod.rs
+++ b/siddhi_rust/src/core/query/selector/attribute/aggregator/mod.rs
@@ -344,3 +344,85 @@ minmax_exec!(MinAttributeAggregatorExecutor, |v,current| v<current);
 minmax_exec!(MaxAttributeAggregatorExecutor, |v,current| v>current);
 minmax_exec!(MinForeverAttributeAggregatorExecutor, |v,current| v<current);
 minmax_exec!(MaxForeverAttributeAggregatorExecutor, |v,current| v>current);
+
+use crate::core::extension::AttributeAggregatorFactory;
+
+#[derive(Debug, Clone)]
+pub struct SumAttributeAggregatorFactory;
+
+impl AttributeAggregatorFactory for SumAttributeAggregatorFactory {
+    fn create(&self) -> Box<dyn AttributeAggregatorExecutor> {
+        Box::new(SumAttributeAggregatorExecutor::default())
+    }
+    fn clone_box(&self) -> Box<dyn AttributeAggregatorFactory> { Box::new(Self) }
+}
+
+#[derive(Debug, Clone)]
+pub struct AvgAttributeAggregatorFactory;
+
+impl AttributeAggregatorFactory for AvgAttributeAggregatorFactory {
+    fn create(&self) -> Box<dyn AttributeAggregatorExecutor> {
+        Box::new(AvgAttributeAggregatorExecutor::default())
+    }
+    fn clone_box(&self) -> Box<dyn AttributeAggregatorFactory> { Box::new(Self) }
+}
+
+#[derive(Debug, Clone)]
+pub struct CountAttributeAggregatorFactory;
+
+impl AttributeAggregatorFactory for CountAttributeAggregatorFactory {
+    fn create(&self) -> Box<dyn AttributeAggregatorExecutor> {
+        Box::new(CountAttributeAggregatorExecutor::default())
+    }
+    fn clone_box(&self) -> Box<dyn AttributeAggregatorFactory> { Box::new(Self) }
+}
+
+#[derive(Debug, Clone)]
+pub struct DistinctCountAttributeAggregatorFactory;
+
+impl AttributeAggregatorFactory for DistinctCountAttributeAggregatorFactory {
+    fn create(&self) -> Box<dyn AttributeAggregatorExecutor> {
+        Box::new(DistinctCountAttributeAggregatorExecutor::default())
+    }
+    fn clone_box(&self) -> Box<dyn AttributeAggregatorFactory> { Box::new(Self) }
+}
+
+#[derive(Debug, Clone)]
+pub struct MinAttributeAggregatorFactory;
+
+impl AttributeAggregatorFactory for MinAttributeAggregatorFactory {
+    fn create(&self) -> Box<dyn AttributeAggregatorExecutor> {
+        Box::new(MinAttributeAggregatorExecutor::default())
+    }
+    fn clone_box(&self) -> Box<dyn AttributeAggregatorFactory> { Box::new(Self) }
+}
+
+#[derive(Debug, Clone)]
+pub struct MaxAttributeAggregatorFactory;
+
+impl AttributeAggregatorFactory for MaxAttributeAggregatorFactory {
+    fn create(&self) -> Box<dyn AttributeAggregatorExecutor> {
+        Box::new(MaxAttributeAggregatorExecutor::default())
+    }
+    fn clone_box(&self) -> Box<dyn AttributeAggregatorFactory> { Box::new(Self) }
+}
+
+#[derive(Debug, Clone)]
+pub struct MinForeverAttributeAggregatorFactory;
+
+impl AttributeAggregatorFactory for MinForeverAttributeAggregatorFactory {
+    fn create(&self) -> Box<dyn AttributeAggregatorExecutor> {
+        Box::new(MinForeverAttributeAggregatorExecutor::default())
+    }
+    fn clone_box(&self) -> Box<dyn AttributeAggregatorFactory> { Box::new(Self) }
+}
+
+#[derive(Debug, Clone)]
+pub struct MaxForeverAttributeAggregatorFactory;
+
+impl AttributeAggregatorFactory for MaxForeverAttributeAggregatorFactory {
+    fn create(&self) -> Box<dyn AttributeAggregatorExecutor> {
+        Box::new(MaxForeverAttributeAggregatorExecutor::default())
+    }
+    fn clone_box(&self) -> Box<dyn AttributeAggregatorFactory> { Box::new(Self) }
+}

--- a/siddhi_rust/src/core/siddhi_manager.rs
+++ b/siddhi_rust/src/core/siddhi_manager.rs
@@ -123,6 +123,34 @@ impl SiddhiManager {
         self.siddhi_context.add_scalar_function_factory(name, function_factory);
     }
 
+    pub fn add_window_factory(&self, name: String, factory: Box<dyn crate::core::extension::WindowProcessorFactory>) {
+        self.siddhi_context.add_window_factory(name, factory);
+    }
+
+    pub fn add_attribute_aggregator_factory(&self, name: String, factory: Box<dyn crate::core::extension::AttributeAggregatorFactory>) {
+        self.siddhi_context.add_attribute_aggregator_factory(name, factory);
+    }
+
+    pub fn add_source_factory(&self, name: String, factory: Box<dyn crate::core::extension::SourceFactory>) {
+        self.siddhi_context.add_source_factory(name, factory);
+    }
+
+    pub fn add_sink_factory(&self, name: String, factory: Box<dyn crate::core::extension::SinkFactory>) {
+        self.siddhi_context.add_sink_factory(name, factory);
+    }
+
+    pub fn add_store_factory(&self, name: String, factory: Box<dyn crate::core::extension::StoreFactory>) {
+        self.siddhi_context.add_store_factory(name, factory);
+    }
+
+    pub fn add_source_mapper_factory(&self, name: String, factory: Box<dyn crate::core::extension::SourceMapperFactory>) {
+        self.siddhi_context.add_source_mapper_factory(name, factory);
+    }
+
+    pub fn add_sink_mapper_factory(&self, name: String, factory: Box<dyn crate::core::extension::SinkMapperFactory>) {
+        self.siddhi_context.add_sink_mapper_factory(name, factory);
+    }
+
     // Specific method for adding data sources
     pub fn add_data_source(&self, name: String, data_source: Arc<dyn DataSource>) {
         self.siddhi_context.add_data_source(name, data_source);

--- a/siddhi_rust/src/core/util/parser/expression_parser.rs
+++ b/siddhi_rust/src/core/util/parser/expression_parser.rs
@@ -398,8 +398,20 @@ pub fn parse_expression<'a>( // Added lifetime 'a
                     exec.init(arg_execs, ProcessingMode::BATCH, false, &context.siddhi_query_context)?;
                     Ok(Box::new(exec))
                 }
-                _ => { // UDF lookup from context
-                    if let Some(scalar_fn_factory) = context.siddhi_app_context.get_siddhi_context().get_scalar_function_factory(&function_lookup_name) {
+                _ => {
+                    if let Some(factory) = context
+                        .siddhi_app_context
+                        .get_siddhi_context()
+                        .get_attribute_aggregator_factory(&function_lookup_name)
+                    {
+                        let mut exec = factory.create();
+                        exec.init(arg_execs, ProcessingMode::BATCH, false, &context.siddhi_query_context)?;
+                        Ok(exec)
+                    } else if let Some(scalar_fn_factory) = context
+                        .siddhi_app_context
+                        .get_siddhi_context()
+                        .get_scalar_function_factory(&function_lookup_name)
+                    {
                         Ok(Box::new(
                             AttributeFunctionExpressionExecutor::new(
                                 scalar_fn_factory.clone_scalar_function(),

--- a/siddhi_rust/tests/extensions.rs
+++ b/siddhi_rust/tests/extensions.rs
@@ -1,0 +1,93 @@
+use siddhi_rust::core::siddhi_manager::SiddhiManager;
+use siddhi_rust::core::extension::{WindowProcessorFactory, AttributeAggregatorFactory};
+use siddhi_rust::core::query::processor::{CommonProcessorMeta, Processor, ProcessingMode};
+use siddhi_rust::core::query::processor::stream::window::WindowProcessor;
+use siddhi_rust::core::config::{siddhi_app_context::SiddhiAppContext, siddhi_query_context::SiddhiQueryContext};
+use siddhi_rust::core::event::complex_event::ComplexEvent;
+use siddhi_rust::query_api::siddhi_app::SiddhiApp;
+use siddhi_rust::query_api::execution::query::input::handler::WindowHandler;
+use siddhi_rust::core::event::value::AttributeValue;
+use siddhi_rust::query_api::definition::{StreamDefinition, attribute::Type as AttrType};
+use siddhi_rust::core::util::parser::{ExpressionParserContext, parse_expression};
+use siddhi_rust::query_api::expression::Expression;
+use std::sync::{Arc, Mutex};
+use std::collections::HashMap;
+
+#[derive(Debug)]
+struct DummyWindowProcessor { meta: CommonProcessorMeta }
+impl Processor for DummyWindowProcessor {
+    fn process(&self, _c: Option<Box<dyn ComplexEvent>>) {}
+    fn next_processor(&self) -> Option<Arc<Mutex<dyn Processor>>> { None }
+    fn set_next_processor(&mut self, _next: Option<Arc<Mutex<dyn Processor>>>) {}
+    fn clone_processor(&self, q:&Arc<SiddhiQueryContext>) -> Box<dyn Processor> { Box::new(DummyWindowProcessor{ meta: CommonProcessorMeta::new(Arc::clone(&self.meta.siddhi_app_context), Arc::clone(q)) }) }
+    fn get_siddhi_app_context(&self) -> Arc<SiddhiAppContext> { Arc::clone(&self.meta.siddhi_app_context) }
+    fn get_processing_mode(&self) -> ProcessingMode { ProcessingMode::BATCH }
+    fn is_stateful(&self) -> bool { true }
+}
+impl WindowProcessor for DummyWindowProcessor {}
+
+#[derive(Debug, Clone)]
+struct DummyWindowFactory;
+impl WindowProcessorFactory for DummyWindowFactory {
+    fn create(&self, _h:&WindowHandler, app:Arc<SiddhiAppContext>, q:Arc<SiddhiQueryContext>) -> Result<Arc<Mutex<dyn Processor>>, String> {
+        Ok(Arc::new(Mutex::new(DummyWindowProcessor{ meta: CommonProcessorMeta::new(app,q) })))
+    }
+    fn clone_box(&self) -> Box<dyn WindowProcessorFactory> { Box::new(Self) }
+}
+
+#[derive(Debug, Clone)]
+struct ConstAggFactory;
+#[derive(Debug, Default)]
+struct ConstAggExec;
+impl AttributeAggregatorFactory for ConstAggFactory {
+    fn create(&self) -> Box<dyn siddhi_rust::core::query::selector::attribute::aggregator::AttributeAggregatorExecutor> { Box::new(ConstAggExec::default()) }
+    fn clone_box(&self) -> Box<dyn AttributeAggregatorFactory> { Box::new(Self) }
+}
+use siddhi_rust::core::query::selector::attribute::aggregator::AttributeAggregatorExecutor;
+use siddhi_rust::core::executor::expression_executor::ExpressionExecutor;
+impl AttributeAggregatorExecutor for ConstAggExec {
+    fn init(&mut self, _e: Vec<Box<dyn ExpressionExecutor>>, _m: ProcessingMode, _ex: bool, _ctx: &SiddhiQueryContext) -> Result<(), String> { Ok(()) }
+    fn process_add(&self, _d: Option<AttributeValue>) -> Option<AttributeValue> { Some(AttributeValue::Int(42)) }
+    fn process_remove(&self, _d: Option<AttributeValue>) -> Option<AttributeValue> { Some(AttributeValue::Int(42)) }
+    fn reset(&self) -> Option<AttributeValue> { Some(AttributeValue::Int(42)) }
+    fn clone_box(&self) -> Box<dyn AttributeAggregatorExecutor> { Box::new(ConstAggExec::default()) }
+}
+impl ExpressionExecutor for ConstAggExec {
+    fn execute(&self, _e: Option<&dyn ComplexEvent>) -> Option<AttributeValue> { Some(AttributeValue::Int(42)) }
+    fn get_return_type(&self) -> AttrType { AttrType::INT }
+    fn clone_executor(&self, _ctx:&Arc<SiddhiAppContext>) -> Box<dyn ExpressionExecutor> { Box::new(ConstAggExec::default()) }
+    fn is_attribute_aggregator(&self) -> bool { true }
+}
+
+fn make_ctx_with_manager(manager: &SiddhiManager, name:&str) -> ExpressionParserContext<'static> {
+    let app = Arc::new(SiddhiApp::new("app".to_string()));
+    let app_ctx = Arc::new(SiddhiAppContext::new(manager.siddhi_context(), "app".to_string(), Arc::clone(&app), String::new()));
+    let q_ctx = Arc::new(SiddhiQueryContext::new(Arc::clone(&app_ctx), name.to_string(), None));
+    let stream_def = Arc::new(StreamDefinition::new("s".to_string()).attribute("v".to_string(), AttrType::INT));
+    let meta = siddhi_rust::core::event::stream::meta_stream_event::MetaStreamEvent::new_for_single_input(Arc::clone(&stream_def));
+    let mut smap = HashMap::new();
+    smap.insert("s".to_string(), Arc::new(meta));
+    ExpressionParserContext{ siddhi_app_context: app_ctx, siddhi_query_context: q_ctx, stream_meta_map: smap, table_meta_map: HashMap::new(), default_source: "s".to_string(), query_name: Box::leak(name.to_string().into_boxed_str()) }
+}
+
+#[test]
+fn test_register_window_factory() {
+    let manager = SiddhiManager::new();
+    manager.add_window_factory("dummy".to_string(), Box::new(DummyWindowFactory));
+    let handler = WindowHandler::new("dummy".to_string(), None, vec![]);
+    let app = Arc::new(SiddhiApp::new("A".to_string()));
+    let app_ctx = Arc::new(SiddhiAppContext::new(manager.siddhi_context(), "A".to_string(), Arc::clone(&app), String::new()));
+    let q_ctx = Arc::new(SiddhiQueryContext::new(Arc::clone(&app_ctx), "q".to_string(), None));
+    let res = siddhi_rust::core::query::processor::stream::window::create_window_processor(&handler, app_ctx, q_ctx);
+    assert!(res.is_ok());
+}
+
+#[test]
+fn test_register_attribute_aggregator_factory() {
+    let manager = SiddhiManager::new();
+    manager.add_attribute_aggregator_factory("constAgg".to_string(), Box::new(ConstAggFactory));
+    let ctx = make_ctx_with_manager(&manager, "agg");
+    let expr = Expression::function_no_ns("constAgg".to_string(), vec![]);
+    let exec = parse_expression(&expr, &ctx).unwrap();
+    assert_eq!(exec.execute(None), Some(AttributeValue::Int(42)));
+}


### PR DESCRIPTION
## Summary
- add extension management framework to SiddhiContext
- register default windows and aggregators
- expose extension registration APIs via SiddhiManager
- use registered factories when building windows and aggregators
- document extension registration
- test window and aggregator extensions

## Testing
- `cargo test --no-run`
- `cargo test --test extensions -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_6847a3908f1c8325948f6af883e9ab2d