### PR TITLE
Initialize data source with stored config

### DIFF
--- a/siddhi_rust/README.md
+++ b/siddhi_rust/README.md
@@ -45,7 +45,7 @@ This port is **far from feature-complete** with the Java version. Users should b
     *   **Patterns & Sequences**: No pattern or sequence processors implemented.
     *   **Aggregations**: Basic attribute aggregator executors (sum, avg, count, distinctCount, min/max and forever variants) are implemented for use in queries.
 *   **State Management & Persistence**:
-    *   **Tables**: An `InMemoryTable` implementation supports insert, update, delete and membership checks.
+    *   **Tables**: An `InMemoryTable` implementation supports insert, update, delete and membership checks. Custom table implementations can be provided via `TableFactory` instances registered with the `SiddhiManager`.
     *   **Persistence**: `SnapshotService` and `PersistenceStore` framework is not implemented. No state persistence or recovery.
 *   **Runtime & Orchestration**:
     *   `SiddhiAppParser` & `QueryParser`: Can only handle very simple queries (single stream, optional filter, simple select, insert into). Cannot parse partitions, windows, joins, patterns, sequences, tables, aggregations.
@@ -55,7 +55,7 @@ This port is **far from feature-complete** with the Java version. Users should b
 *   **Extensions Framework**:
     *   `ScalarFunctionExecutor` allows registering stateful user-defined functions.
     *   Placeholders for other extension types (Window, Sink, Source, Store, Mapper, AttributeAggregator, Script) are largely missing.
-*   **DataSources**: `DataSource` trait is a placeholder. No actual implementations or integration with table stores.
+*   **DataSources**: `DataSource` trait is a placeholder. No actual implementations or integration with table stores. `SiddhiContext::add_data_source` now looks for a matching configuration and calls `init` on the `DataSource` with it when registering using a temporary `SiddhiAppContext` (`dummy_ctx`).
 *   **Concurrency**: While `Arc<Mutex<T>>` is used in places, detailed analysis and implementation of Siddhi's concurrency model (thread pools for async junctions, partitioned execution) are pending.
 
 ## Testing Status
@@ -80,6 +80,8 @@ let ctx = manager.siddhi_context();
 let table: Arc<dyn Table> = Arc::new(InMemoryTable::new());
 table.insert(&[AttributeValue::Int(1)]);
 ctx.add_table("MyTable".to_string(), table);
+// custom tables can be registered via factories
+// manager.add_table_factory("jdbc".to_string(), Box::new(MyJdbcTableFactory));
 ```
 
 User-defined scalar functions implement `ScalarFunctionExecutor` and are registered with the manager:

--- a/siddhi_rust/src/core/extension/mod.rs
+++ b/siddhi_rust/src/core/extension/mod.rs
@@ -52,3 +52,14 @@ pub trait SinkMapperFactory: Debug + Send + Sync {
     fn clone_box(&self) -> Box<dyn SinkMapperFactory>;
 }
 impl Clone for Box<dyn SinkMapperFactory> { fn clone(&self) -> Self { self.clone_box() } }
+
+pub trait TableFactory: Debug + Send + Sync {
+    fn create(
+        &self,
+        table_name: String,
+        properties: std::collections::HashMap<String, String>,
+        ctx: Arc<crate::core::config::siddhi_context::SiddhiContext>,
+    ) -> Result<Arc<dyn crate::core::table::Table>, String>;
+    fn clone_box(&self) -> Box<dyn TableFactory>;
+}
+impl Clone for Box<dyn TableFactory> { fn clone(&self) -> Self { self.clone_box() } }

--- a/siddhi_rust/src/core/siddhi_manager.rs
+++ b/siddhi_rust/src/core/siddhi_manager.rs
@@ -151,6 +151,10 @@ impl SiddhiManager {
         self.siddhi_context.add_sink_mapper_factory(name, factory);
     }
 
+    pub fn add_table_factory(&self, name: String, factory: Box<dyn crate::core::extension::TableFactory>) {
+        self.siddhi_context.add_table_factory(name, factory);
+    }
+
     // Specific method for adding data sources
     pub fn add_data_source(&self, name: String, data_source: Arc<dyn DataSource>) {
         self.siddhi_context.add_data_source(name, data_source);

--- a/siddhi_rust/src/core/table/mod.rs
+++ b/siddhi_rust/src/core/table/mod.rs
@@ -4,6 +4,10 @@ use std::sync::RwLock;
 mod jdbc_table;
 pub use jdbc_table::JdbcTable;
 use std::fmt::Debug;
+use std::collections::HashMap;
+use crate::core::config::siddhi_context::SiddhiContext;
+use std::sync::Arc;
+use crate::core::extension::TableFactory;
 
 /// Trait representing a table that can store rows of `AttributeValue`s.
 pub trait Table: Debug + Send + Sync {
@@ -86,5 +90,23 @@ impl Table for InMemoryTable {
     fn clone_table(&self) -> Box<dyn Table> {
         let rows = self.rows.read().unwrap().clone();
         Box::new(InMemoryTable { rows: RwLock::new(rows) })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct InMemoryTableFactory;
+
+impl TableFactory for InMemoryTableFactory {
+    fn create(
+        &self,
+        _name: String,
+        _properties: HashMap<String, String>,
+        _ctx: Arc<SiddhiContext>,
+    ) -> Result<Arc<dyn Table>, String> {
+        Ok(Arc::new(InMemoryTable::new()))
+    }
+
+    fn clone_box(&self) -> Box<dyn TableFactory> {
+        Box::new(self.clone())
     }
 }

--- a/siddhi_rust/tests/data_source_init.rs
+++ b/siddhi_rust/tests/data_source_init.rs
@@ -1,0 +1,43 @@
+use siddhi_rust::core::config::siddhi_context::SiddhiContext;
+use siddhi_rust::core::config::siddhi_app_context::SiddhiAppContext;
+use siddhi_rust::core::persistence::data_source::{DataSource, DataSourceConfig};
+use std::sync::{Arc, Mutex};
+use std::any::Any;
+use std::collections::HashMap;
+
+#[derive(Debug)]
+struct MockDataSource {
+    called: Arc<Mutex<Option<DataSourceConfig>>>,
+}
+
+impl MockDataSource {
+    fn new() -> Self {
+        Self { called: Arc::new(Mutex::new(None)) }
+    }
+}
+
+impl DataSource for MockDataSource {
+    fn get_type(&self) -> String { "mock".to_string() }
+    fn init(&mut self, _ctx: &Arc<SiddhiAppContext>, _id: &str, cfg: DataSourceConfig) -> Result<(), String> {
+        *self.called.lock().unwrap() = Some(cfg);
+        Ok(())
+    }
+    fn get_connection(&self) -> Result<Box<dyn Any>, String> { Ok(Box::new(())) }
+    fn shutdown(&mut self) -> Result<(), String> { Ok(()) }
+    fn clone_data_source(&self) -> Box<dyn DataSource> {
+        Box::new(MockDataSource { called: Arc::clone(&self.called) })
+    }
+}
+
+#[test]
+fn test_add_data_source_uses_config() {
+    let ctx = Arc::new(SiddhiContext::new());
+    let mut props = HashMap::new();
+    props.insert("url".to_string(), "mem".to_string());
+    ctx.set_data_source_config("DS".to_string(), DataSourceConfig { r#type: "mock".to_string(), properties: props.clone() });
+    let ds = Arc::new(MockDataSource::new());
+    ctx.add_data_source("DS".to_string(), ds.clone());
+    let stored = ds.called.lock().unwrap().clone();
+    assert!(stored.is_some());
+    assert_eq!(stored.unwrap().properties.get("url"), Some(&"mem".to_string()));
+}


### PR DESCRIPTION
## Summary
- initialize `DataSource` in `SiddhiContext::add_data_source` with dummy context
- add `TableFactory` trait and registration APIs
- implement `InMemoryTableFactory` and `JdbcTableFactory`
- parse table definitions using registered factories
- document data source initialization and table factories in README

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6848fd3d61c883258aff183545a20bbc