### PR TITLE
Enhance expression parser

### DIFF
--- a/siddhi_rust/src/core/util/parser/query_parser.rs
+++ b/siddhi_rust/src/core/util/parser/query_parser.rs
@@ -92,6 +92,8 @@ impl QueryParser {
                     siddhi_query_context: Arc::clone(&siddhi_query_context),
                     stream_meta_map,
                     table_meta_map,
+                    window_meta_map: HashMap::new(),
+                    state_meta_map: HashMap::new(),
                     default_source: input_stream_id.clone(),
                     query_name: &query_name,
                 };
@@ -154,6 +156,8 @@ impl QueryParser {
                         siddhi_query_context: Arc::clone(&siddhi_query_context),
                         stream_meta_map: stream_meta_map.clone(),
                         table_meta_map: table_meta_map.clone(),
+                        window_meta_map: HashMap::new(),
+                        state_meta_map: HashMap::new(),
                         default_source: left_id.clone(),
                         query_name: &query_name,
                     })?)
@@ -187,6 +191,8 @@ impl QueryParser {
                     siddhi_query_context: Arc::clone(&siddhi_query_context),
                     stream_meta_map,
                     table_meta_map,
+                    window_meta_map: HashMap::new(),
+                    state_meta_map: HashMap::new(),
                     default_source: left_id.clone(),
                     query_name: &query_name,
                 };
@@ -256,6 +262,8 @@ impl QueryParser {
                     siddhi_query_context: Arc::clone(&siddhi_query_context),
                     stream_meta_map,
                     table_meta_map,
+                    window_meta_map: HashMap::new(),
+                    state_meta_map: HashMap::new(),
                     default_source: first_id.clone(),
                     query_name: &query_name,
                 }

--- a/siddhi_rust/tests/aggregator_window.rs
+++ b/siddhi_rust/tests/aggregator_window.rs
@@ -28,6 +28,8 @@ fn make_ctx(name: &str) -> ExpressionParserContext<'static> {
         siddhi_query_context: q_ctx,
         stream_meta_map: stream_map,
         table_meta_map: HashMap::new(),
+        window_meta_map: HashMap::new(),
+        state_meta_map: HashMap::new(),
         default_source: "s".to_string(),
         query_name: qn,
     }

--- a/siddhi_rust/tests/builtin_function_parsing.rs
+++ b/siddhi_rust/tests/builtin_function_parsing.rs
@@ -28,6 +28,8 @@ fn empty_ctx(query: &str) -> ExpressionParserContext {
         siddhi_query_context: make_query_ctx(query),
         stream_meta_map: HashMap::new(),
         table_meta_map: HashMap::new(),
+        window_meta_map: HashMap::new(),
+        state_meta_map: HashMap::new(),
         default_source: "dummy".to_string(),
         query_name: query,
     }

--- a/siddhi_rust/tests/extensions.rs
+++ b/siddhi_rust/tests/extensions.rs
@@ -67,7 +67,7 @@ fn make_ctx_with_manager(manager: &SiddhiManager, name:&str) -> ExpressionParser
     let meta = siddhi_rust::core::event::stream::meta_stream_event::MetaStreamEvent::new_for_single_input(Arc::clone(&stream_def));
     let mut smap = HashMap::new();
     smap.insert("s".to_string(), Arc::new(meta));
-    ExpressionParserContext{ siddhi_app_context: app_ctx, siddhi_query_context: q_ctx, stream_meta_map: smap, table_meta_map: HashMap::new(), default_source: "s".to_string(), query_name: Box::leak(name.to_string().into_boxed_str()) }
+    ExpressionParserContext{ siddhi_app_context: app_ctx, siddhi_query_context: q_ctx, stream_meta_map: smap, table_meta_map: HashMap::new(), window_meta_map: HashMap::new(), state_meta_map: HashMap::new(), default_source: "s".to_string(), query_name: Box::leak(name.to_string().into_boxed_str()) }
 }
 
 #[test]

--- a/siddhi_rust/tests/stateful_udf.rs
+++ b/siddhi_rust/tests/stateful_udf.rs
@@ -91,6 +91,8 @@ fn parser_ctx(manager: &SiddhiManager) -> ExpressionParserContext<'static> {
         siddhi_query_context: query_ctx,
         stream_meta_map: HashMap::new(),
         table_meta_map: HashMap::new(),
+        window_meta_map: HashMap::new(),
+        state_meta_map: HashMap::new(),
         default_source: "default".to_string(),
         query_name: "q",
     }


### PR DESCRIPTION
## Summary
- extend `ExpressionParserContext` with window/state mappings
- resolve variables using all provided metadata maps
- handle new built‑in functions `event` and `allEvents`
- add tests for table variables and custom UDFs

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68493c3f17388325a3c5b9bbb3005f3f