### PR TITLE
Support window definition parsing

### DIFF
--- a/siddhi_rust/src/query_compiler/grammar.lalrpop
+++ b/siddhi_rust/src/query_compiler/grammar.lalrpop
@@ -3,8 +3,10 @@
 
 grammar;
 
-use crate::query_api::definition::{StreamDefinition, TableDefinition, AggregationDefinition};
+use crate::query_api::definition::{StreamDefinition, TableDefinition, AggregationDefinition, WindowDefinition};
 use crate::query_api::definition::attribute::Type as AttributeType;
+use crate::query_api::definition::attribute::Attribute;
+use crate::query_api::execution::query::input::handler::WindowHandler;
 use crate::query_api::execution::query::{Query};
 use crate::query_api::execution::query::selection::Selector;
 use crate::query_api::execution::query::output::output_stream::{OutputStream, OutputStreamAction, InsertIntoStreamAction};
@@ -25,6 +27,26 @@ pub TableDef: TableDefinition = {
     "define" "table" <id:Ident> "(" <attrs:AttrList> ")" => {
         let mut d = TableDefinition::new(id);
         for (n,t) in attrs { d = d.attribute(n, t); }
+        d
+    }
+};
+
+pub WindowParam: WindowHandler = {
+    <name:Ident> "(" <args:ExprList> ")" => WindowHandler::new(name, None, args),
+};
+
+WindowParamOpt: Option<WindowHandler> = {
+    <p:WindowParam> => Some(p),
+    => None,
+};
+
+pub WindowDef: WindowDefinition = {
+    "define" "window" <id:Ident> "(" <attrs:AttrList> ")" <param:WindowParamOpt> => {
+        let mut d = WindowDefinition::new(id);
+        for (n, t) in attrs {
+            d.stream_definition.abstract_definition.attribute_list.push(Attribute::new(n, t));
+        }
+        if let Some(w) = param { d = d.window(w); }
         d
     }
 };

--- a/siddhi_rust/src/query_compiler/mod.rs
+++ b/siddhi_rust/src/query_compiler/mod.rs
@@ -6,6 +6,7 @@ pub use self::siddhi_compiler::{
     parse,
     parse_stream_definition,
     parse_table_definition,
+    parse_window_definition,
     parse_aggregation_definition,
     parse_partition,
     parse_query,

--- a/siddhi_rust/src/query_compiler/siddhi_compiler.rs
+++ b/siddhi_rust/src/query_compiler/siddhi_compiler.rs
@@ -2,7 +2,7 @@
 // Ensure these paths are correct based on query_api module structure and re-exports.
 use crate::query_api::{
     SiddhiApp,
-    definition::{StreamDefinition, TableDefinition, AggregationDefinition, FunctionDefinition, attribute::Type as AttributeType},
+    definition::{StreamDefinition, TableDefinition, WindowDefinition, AggregationDefinition, FunctionDefinition, attribute::Type as AttributeType},
     execution::{
         Partition,
         query::{Query, OnDemandQuery, StoreQuery, input::InputStream, output::output_stream::{OutputStream, OutputStreamAction, InsertIntoStreamAction}, selection::Selector},
@@ -90,6 +90,9 @@ pub fn parse(siddhi_app_string: &str) -> Result<SiddhiApp, String> {
         } else if lower.starts_with("define table") {
             let def = parse_table_definition(stmt)?;
             app.add_table_definition(def);
+        } else if lower.starts_with("define window") {
+            let def = parse_window_definition(stmt)?;
+            app.add_window_definition(def);
         } else if lower.starts_with("from") {
             let q = parse_query(stmt)?;
             app.add_execution_element(ExecutionElement::Query(q));
@@ -109,6 +112,13 @@ pub fn parse_stream_definition(stream_def_string: &str) -> Result<StreamDefiniti
 pub fn parse_table_definition(table_def_string: &str) -> Result<TableDefinition, String> {
     let s = update_variables(table_def_string)?;
     grammar::TableDefParser::new()
+        .parse(&s)
+        .map_err(|e| format!("{:?}", e))
+}
+
+pub fn parse_window_definition(window_def_string: &str) -> Result<WindowDefinition, String> {
+    let s = update_variables(window_def_string)?;
+    grammar::WindowDefParser::new()
         .parse(&s)
         .map_err(|e| format!("{:?}", e))
 }

--- a/siddhi_rust/tests/parser_tests.rs
+++ b/siddhi_rust/tests/parser_tests.rs
@@ -1,4 +1,4 @@
-use siddhi_rust::query_compiler::{parse_stream_definition, parse_table_definition, parse_query};
+use siddhi_rust::query_compiler::{parse_stream_definition, parse_table_definition, parse_window_definition, parse_query};
 use siddhi_rust::query_api::definition::attribute::Type as AttrType;
 use siddhi_rust::query_api::execution::query::input::stream::input_stream::InputStreamTrait;
 
@@ -31,4 +31,17 @@ fn test_parse_query() {
     assert_eq!(q.get_input_stream().unwrap().get_all_stream_ids()[0], "Input");
     assert_eq!(q.get_output_stream().get_target_id().unwrap(), "Out");
     assert_eq!(q.get_selector().selection_list.len(), 2);
+}
+
+#[test]
+fn test_parse_window_definition() {
+    let def = parse_window_definition("define window Win (symbol string) length(5)").unwrap();
+    assert_eq!(def.stream_definition.abstract_definition.id, "Win");
+    let attrs = &def.stream_definition.abstract_definition.attribute_list;
+    assert_eq!(attrs.len(), 1);
+    assert_eq!(attrs[0].name, "symbol");
+    assert_eq!(attrs[0].attribute_type, AttrType::STRING);
+    let handler = def.window_handler.expect("window handler");
+    assert_eq!(handler.name, "length");
+    assert_eq!(handler.parameters.len(), 1);
 }


### PR DESCRIPTION
## Summary
- extend Siddhi grammar with `WindowDef` rule
- parse window definitions in the compiler
- export `parse_window_definition`
- handle window defs in Siddhi app parser
- test parsing of simple window definitions

## Testing
- `cargo test --no-run`
- `cargo test --test parser_tests test_parse_window_definition`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684940f14e1c8325888400d9ea5adb45