### PR TITLE
Add arithmetic/logic expression parsing

### DIFF
--- a/siddhi_rust/src/query_compiler/grammar.lalrpop
+++ b/siddhi_rust/src/query_compiler/grammar.lalrpop
@@ -14,6 +14,7 @@ use crate::query_api::execution::query::input::{
     InputStream, SingleInputStream, JoinType, StateInputStreamType, StateElement, State,
 };
 use crate::query_api::expression::{Expression, variable::Variable};
+use crate::query_api::expression::condition::compare::Operator as CompareOperator;
 use crate::query_api::aggregation::TimePeriod;
 use crate::query_api::aggregation::time_period::Duration as TimeDuration;
 use crate::query_api::annotation::Annotation;
@@ -250,9 +251,50 @@ Type: AttributeType = {
     "object" => AttributeType::OBJECT,
 };
 
-pub Expression: Expression = {
+pub Expression: Expression = { <e:OrExpr> => e };
+
+OrExpr: Expression = {
+    <l:OrExpr> "or" <r:AndExpr> => Expression::or(l, r),
+    <e:AndExpr> => e,
+};
+
+AndExpr: Expression = {
+    <l:AndExpr> "and" <r:NotExpr> => Expression::and(l, r),
+    <e:NotExpr> => e,
+};
+
+NotExpr: Expression = {
+    "not" <e:NotExpr> => Expression::not(e),
+    <e:CompareExpr> => e,
+};
+
+CompareExpr: Expression = {
+    <l:AddExpr> ">=" <r:AddExpr> => Expression::compare(l, CompareOperator::GreaterThanEqual, r),
+    <l:AddExpr> "<=" <r:AddExpr> => Expression::compare(l, CompareOperator::LessThanEqual, r),
+    <l:AddExpr> ">" <r:AddExpr> => Expression::compare(l, CompareOperator::GreaterThan, r),
+    <l:AddExpr> "<" <r:AddExpr> => Expression::compare(l, CompareOperator::LessThan, r),
+    <l:AddExpr> "==" <r:AddExpr> => Expression::compare(l, CompareOperator::Equal, r),
+    <l:AddExpr> "!=" <r:AddExpr> => Expression::compare(l, CompareOperator::NotEqual, r),
+    <e:AddExpr> => e,
+};
+
+AddExpr: Expression = {
+    <l:AddExpr> "+" <r:MulExpr> => Expression::add(l, r),
+    <l:AddExpr> "-" <r:MulExpr> => Expression::subtract(l, r),
+    <e:MulExpr> => e,
+};
+
+MulExpr: Expression = {
+    <l:MulExpr> "*" <r:PrimaryExpr> => Expression::multiply(l, r),
+    <l:MulExpr> "/" <r:PrimaryExpr> => Expression::divide(l, r),
+    <e:PrimaryExpr> => e,
+};
+
+PrimaryExpr: Expression = {
+    "(" <e:Expression> ")" => e,
     <s:STRING> => Expression::value_string(s),
     <n:NUMBER> => Expression::value_long(n),
+    "-" <n:NUMBER> => Expression::value_long(-n),
     <id:Ident> "(" <args:ExprList> ")" => Expression::function_no_ns(id, args),
     <id:Ident> => Expression::variable(id),
 };

--- a/siddhi_rust/tests/grammar_expression.rs
+++ b/siddhi_rust/tests/grammar_expression.rs
@@ -1,0 +1,48 @@
+use siddhi_rust::query_compiler::parse_expression;
+use siddhi_rust::query_api::expression::Expression;
+use siddhi_rust::query_api::expression::condition::compare::Operator as CompareOp;
+
+#[test]
+fn test_arithmetic_precedence() {
+    let expr = parse_expression("1 + 2 * 3").unwrap();
+    let expected = Expression::add(
+        Expression::value_long(1),
+        Expression::multiply(
+            Expression::value_long(2),
+            Expression::value_long(3),
+        ),
+    );
+    assert_eq!(expr, expected);
+}
+
+#[test]
+fn test_boolean_logic_precedence() {
+    let expr = parse_expression("not a and b or c").unwrap();
+    let expected = Expression::or(
+        Expression::and(
+            Expression::not(Expression::variable("a".to_string())),
+            Expression::variable("b".to_string()),
+        ),
+        Expression::variable("c".to_string()),
+    );
+    assert_eq!(expr, expected);
+}
+
+#[test]
+fn test_comparison_and_parentheses() {
+    let expr = parse_expression("(a + 1) * 2 > b - 3").unwrap();
+    let left = Expression::multiply(
+        Expression::add(
+            Expression::variable("a".to_string()),
+            Expression::value_long(1),
+        ),
+        Expression::value_long(2),
+    );
+    let right = Expression::subtract(
+        Expression::variable("b".to_string()),
+        Expression::value_long(3),
+    );
+    let expected = Expression::compare(left, CompareOp::GreaterThan, right);
+    assert_eq!(expr, expected);
+}
+


### PR DESCRIPTION
## Summary
- extend grammar to parse arithmetic and boolean operators
- support comparisons and parentheses
- add integration tests covering complex expression parsing

## Testing
- `cargo test --test grammar_expression -- --show-output`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68495b922e7c8325a7c27d22f98dab4c