### PR TITLE
Add state event utilities

### DIFF
--- a/siddhi_rust/src/core/event/state/README.md
+++ b/siddhi_rust/src/core/event/state/README.md
@@ -13,10 +13,7 @@ portion required for the current prototype is implemented.
   position within a `StateEvent`.
 - `StateEventFactory` – helper for constructing `StateEvent` instances based on
   meta information.
-
-## Missing Parts / TODO
-
-The original Java package contains additional helpers such as
-`StateEventCloner` and a set of *populator* utilities used by the pattern and
-partition runtime.  These have not yet been ported.  A future milestone should
-add them when those engine features are implemented.
+- `StateEventCloner` – shallow cloning utility for `StateEvent` used by stateful
+  processors.
+- *Populator* utilities (`StateEventPopulator`, etc.) – used to copy attributes
+  between events when constructing `StateEvent` instances.

--- a/siddhi_rust/src/core/event/state/mod.rs
+++ b/siddhi_rust/src/core/event/state/mod.rs
@@ -4,10 +4,12 @@ pub mod state_event;
 pub mod meta_state_event;
 pub mod state_event_factory;
 pub mod meta_state_event_attribute; // MetaStateEventAttribute.java
-// pub mod state_event_cloner;
-// pub mod populater; // for sub-package
+pub mod state_event_cloner;
+pub mod populater; // for sub-package
 
 pub use self::state_event::StateEvent;
 pub use self::meta_state_event::MetaStateEvent;
 pub use self::state_event_factory::StateEventFactory;
 pub use self::meta_state_event_attribute::MetaStateEventAttribute;
+pub use self::state_event_cloner::StateEventCloner;
+pub use self::populater::*;

--- a/siddhi_rust/src/core/event/state/populater/mod.rs
+++ b/siddhi_rust/src/core/event/state/populater/mod.rs
@@ -1,0 +1,10 @@
+// siddhi_rust/src/core/event/state/populater/mod.rs
+pub mod state_event_populator;
+pub mod skip_state_event_populator;
+pub mod selective_state_event_populator;
+pub mod state_mapping_element;
+
+pub use state_event_populator::StateEventPopulator;
+pub use skip_state_event_populator::SkipStateEventPopulator;
+pub use selective_state_event_populator::SelectiveStateEventPopulator;
+pub use state_mapping_element::StateMappingElement;

--- a/siddhi_rust/src/core/event/state/populater/selective_state_event_populator.rs
+++ b/siddhi_rust/src/core/event/state/populater/selective_state_event_populator.rs
@@ -1,0 +1,29 @@
+// siddhi_rust/src/core/event/state/populater/selective_state_event_populator.rs
+use super::{state_event_populator::StateEventPopulator, state_mapping_element::StateMappingElement};
+use crate::core::event::complex_event::ComplexEvent;
+use crate::core::event::state::state_event::StateEvent;
+
+#[derive(Debug, Clone)]
+pub struct SelectiveStateEventPopulator {
+    pub mappings: Vec<StateMappingElement>,
+}
+
+impl SelectiveStateEventPopulator {
+    pub fn new(mappings: Vec<StateMappingElement>) -> Self {
+        Self { mappings }
+    }
+}
+
+impl StateEventPopulator for SelectiveStateEventPopulator {
+    fn populate_state_event(&self, complex_event: &mut dyn ComplexEvent) {
+        let state_event = match complex_event.as_any_mut().downcast_mut::<StateEvent>() {
+            Some(se) => se,
+            None => return,
+        };
+        for mapping in &self.mappings {
+            if let Some(val) = state_event.get_attribute(&mapping.from_position) {
+                let _ = state_event.set_output_data_at_idx(val.clone(), mapping.to_position);
+            }
+        }
+    }
+}

--- a/siddhi_rust/src/core/event/state/populater/skip_state_event_populator.rs
+++ b/siddhi_rust/src/core/event/state/populater/skip_state_event_populator.rs
@@ -1,0 +1,12 @@
+// siddhi_rust/src/core/event/state/populater/skip_state_event_populator.rs
+use super::state_event_populator::StateEventPopulator;
+use crate::core::event::complex_event::ComplexEvent;
+
+#[derive(Debug, Clone)]
+pub struct SkipStateEventPopulator;
+
+impl StateEventPopulator for SkipStateEventPopulator {
+    fn populate_state_event(&self, _complex_event: &mut dyn ComplexEvent) {
+        // intentionally no-op
+    }
+}

--- a/siddhi_rust/src/core/event/state/populater/state_event_populator.rs
+++ b/siddhi_rust/src/core/event/state/populater/state_event_populator.rs
@@ -1,0 +1,6 @@
+// siddhi_rust/src/core/event/state/populater/state_event_populator.rs
+use crate::core::event::complex_event::ComplexEvent;
+
+pub trait StateEventPopulator {
+    fn populate_state_event(&self, complex_event: &mut dyn ComplexEvent);
+}

--- a/siddhi_rust/src/core/event/state/populater/state_event_populator_factory.rs
+++ b/siddhi_rust/src/core/event/state/populater/state_event_populator_factory.rs
@@ -1,0 +1,27 @@
+// siddhi_rust/src/core/event/state/populater/state_event_populator_factory.rs
+use super::{
+    selective_state_event_populator::SelectiveStateEventPopulator,
+    skip_state_event_populator::SkipStateEventPopulator,
+    state_event_populator::StateEventPopulator,
+    state_mapping_element::StateMappingElement,
+};
+use crate::core::event::state::{MetaStateEvent, MetaStateEventAttribute};
+use crate::core::event::stream::meta_stream_event::MetaStreamEvent;
+
+pub fn construct_event_populator(meta: &MetaStateEvent) -> Box<dyn StateEventPopulator> {
+    if meta.stream_event_count() == 1 {
+        // Single stream events don't need population
+        Box::new(SkipStateEventPopulator)
+    } else {
+        let mut mappings = Vec::new();
+        let mut to_index = 0usize;
+        if let Some(attrs) = &meta.output_data_attributes {
+            for attr in attrs {
+                let mapping = StateMappingElement::new(attr.position.clone(), to_index);
+                mappings.push(mapping);
+                to_index += 1;
+            }
+        }
+        Box::new(SelectiveStateEventPopulator::new(mappings))
+    }
+}

--- a/siddhi_rust/src/core/event/state/populater/state_mapping_element.rs
+++ b/siddhi_rust/src/core/event/state/populater/state_mapping_element.rs
@@ -1,0 +1,12 @@
+// siddhi_rust/src/core/event/state/populater/state_mapping_element.rs
+#[derive(Debug, Clone)]
+pub struct StateMappingElement {
+    pub from_position: Vec<i32>,
+    pub to_position: usize,
+}
+
+impl StateMappingElement {
+    pub fn new(from_position: Vec<i32>, to_position: usize) -> Self {
+        Self { from_position, to_position }
+    }
+}

--- a/siddhi_rust/src/core/event/state/state_event_cloner.rs
+++ b/siddhi_rust/src/core/event/state/state_event_cloner.rs
@@ -1,0 +1,41 @@
+// siddhi_rust/src/core/event/state/state_event_cloner.rs
+// Simplified port of io.siddhi.core.event.state.StateEventCloner
+use super::{state_event::StateEvent, meta_state_event::MetaStateEvent, state_event_factory::StateEventFactory};
+
+#[derive(Debug, Clone)]
+pub struct StateEventCloner {
+    stream_event_size: usize,
+    output_data_size: usize,
+    state_event_factory: StateEventFactory,
+}
+
+impl StateEventCloner {
+    pub fn new(meta: &MetaStateEvent, factory: StateEventFactory) -> Self {
+        Self {
+            stream_event_size: meta.stream_event_count(),
+            output_data_size: meta.get_output_data_attributes().len(),
+            state_event_factory: factory,
+        }
+    }
+
+    pub fn copy_state_event(&self, state_event: &StateEvent) -> StateEvent {
+        let mut new_event = self.state_event_factory.new_instance();
+        if self.output_data_size > 0 {
+            if let (Some(src), Some(dest)) = (&state_event.output_data, &mut new_event.output_data) {
+                for i in 0..self.output_data_size {
+                    dest[i] = src[i].clone();
+                }
+            }
+        }
+        if self.stream_event_size > 0 {
+            for i in 0..self.stream_event_size {
+                new_event.stream_events[i] = state_event.stream_events[i].clone();
+            }
+        }
+        new_event.event_type = state_event.event_type;
+        new_event.timestamp = state_event.timestamp;
+        new_event.id = state_event.id;
+        new_event
+    }
+}
+


### PR DESCRIPTION
## Summary
- add state event cloner and populater modules
- expose new modules in `core::event::state`
- document new utilities in README

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68496aafdd708325abffab7d3ed96774