### PR TITLE
Implement simple persistence store integration

### DIFF
--- a/siddhi_rust/src/core/siddhi_app_runtime.rs
+++ b/siddhi_rust/src/core/siddhi_app_runtime.rs
@@ -62,7 +62,11 @@ impl SiddhiAppRuntime {
             Arc::clone(&api_siddhi_app),
             String::new(),
         );
-        let snapshot_service = Arc::new(SnapshotService::new(app_name.clone()));
+        let mut ss = SnapshotService::new(app_name.clone());
+        if let Some(store) = ctx.siddhi_context.get_persistence_store() {
+            ss.persistence_store = Some(store);
+        }
+        let snapshot_service = Arc::new(ss);
         ctx.set_snapshot_service(Arc::clone(&snapshot_service));
         let siddhi_app_context = Arc::new(ctx);
 

--- a/siddhi_rust/src/core/siddhi_manager.rs
+++ b/siddhi_rust/src/core/siddhi_manager.rs
@@ -10,7 +10,8 @@ use crate::query_compiler::parse as parse_siddhi_ql_string_to_api_app;
 use crate::core::executor::ScalarFunctionExecutor; // Added for UDFs
 use crate::core::DataSource; // Added for data sources
 // Placeholder for actual persistence store trait/type
-use crate::core::config::siddhi_context::{PersistenceStorePlaceholder, ConfigManagerPlaceholder, ExtensionClassPlaceholder, DataSourcePlaceholder};
+use crate::core::config::siddhi_context::{ConfigManagerPlaceholder, ExtensionClassPlaceholder, DataSourcePlaceholder};
+use crate::core::persistence::{PersistenceStore, IncrementalPersistenceStore};
 
 
 use std::collections::HashMap;
@@ -164,10 +165,8 @@ impl SiddhiManager {
     // pub fn set_data_source(&self, name: &str, ds_placeholder: DataSourcePlaceholder) -> Result<(), String> { ... }
 
 
-    pub fn set_persistence_store(&self, _ps_placeholder: PersistenceStorePlaceholder) -> Result<(), String> {
-        // self.siddhi_context.set_persistence_store(ps_placeholder);
-        println!("[SiddhiManager] set_persistence_store called (Placeholder)");
-        Ok(())
+    pub fn set_persistence_store(&self, store: Arc<dyn PersistenceStore>) {
+        self.siddhi_context.set_persistence_store(store);
     }
 
     pub fn set_config_manager(&self, _cm_placeholder: ConfigManagerPlaceholder) -> Result<(), String> {


### PR DESCRIPTION
## Summary
- implement PersistenceStore wiring into `SiddhiContext` and `SiddhiManager`
- allow `SiddhiAppRuntime` to use registered store via `SnapshotService`
- add new test covering runtime persist/restore behaviour

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68496f7219e08325b2022e0d3d6f6772