### PR TITLE
Extend Siddhi context with extension factories

### DIFF
--- a/siddhi_rust/src/core/config/siddhi_context.rs
+++ b/siddhi_rust/src/core/config/siddhi_context.rs
@@ -293,6 +293,8 @@ impl SiddhiContext {
             DistinctCountAttributeAggregatorFactory, MinAttributeAggregatorFactory, MaxAttributeAggregatorFactory,
             MinForeverAttributeAggregatorFactory, MaxForeverAttributeAggregatorFactory,
         };
+        use crate::core::table::InMemoryTableFactory;
+        use crate::core::extension::{LogSinkFactory, ExampleSourceFactory};
 
         self.add_window_factory("length".to_string(), Box::new(LengthWindowFactory));
         self.add_window_factory("time".to_string(), Box::new(TimeWindowFactory));
@@ -305,6 +307,10 @@ impl SiddhiContext {
         self.add_attribute_aggregator_factory("max".to_string(), Box::new(MaxAttributeAggregatorFactory));
         self.add_attribute_aggregator_factory("minForever".to_string(), Box::new(MinForeverAttributeAggregatorFactory));
         self.add_attribute_aggregator_factory("maxForever".to_string(), Box::new(MaxForeverAttributeAggregatorFactory));
+
+        self.add_table_factory("inMemory".to_string(), Box::new(InMemoryTableFactory));
+        self.add_source_factory("example".to_string(), Box::new(ExampleSourceFactory));
+        self.add_sink_factory("log".to_string(), Box::new(LogSinkFactory));
     }
 
     // --- Extension Factory Methods ---
@@ -327,17 +333,32 @@ impl SiddhiContext {
     pub fn add_source_factory(&self, name: String, factory: Box<dyn crate::core::extension::SourceFactory>) {
         self.source_factories.write().unwrap().insert(name, factory);
     }
+    pub fn get_source_factory(&self, name: &str) -> Option<Box<dyn crate::core::extension::SourceFactory>> {
+        self.source_factories.read().unwrap().get(name).cloned()
+    }
     pub fn add_sink_factory(&self, name: String, factory: Box<dyn crate::core::extension::SinkFactory>) {
         self.sink_factories.write().unwrap().insert(name, factory);
+    }
+    pub fn get_sink_factory(&self, name: &str) -> Option<Box<dyn crate::core::extension::SinkFactory>> {
+        self.sink_factories.read().unwrap().get(name).cloned()
     }
     pub fn add_store_factory(&self, name: String, factory: Box<dyn crate::core::extension::StoreFactory>) {
         self.store_factories.write().unwrap().insert(name, factory);
     }
+    pub fn get_store_factory(&self, name: &str) -> Option<Box<dyn crate::core::extension::StoreFactory>> {
+        self.store_factories.read().unwrap().get(name).cloned()
+    }
     pub fn add_source_mapper_factory(&self, name: String, factory: Box<dyn crate::core::extension::SourceMapperFactory>) {
         self.source_mapper_factories.write().unwrap().insert(name, factory);
     }
+    pub fn get_source_mapper_factory(&self, name: &str) -> Option<Box<dyn crate::core::extension::SourceMapperFactory>> {
+        self.source_mapper_factories.read().unwrap().get(name).cloned()
+    }
     pub fn add_sink_mapper_factory(&self, name: String, factory: Box<dyn crate::core::extension::SinkMapperFactory>) {
         self.sink_mapper_factories.write().unwrap().insert(name, factory);
+    }
+    pub fn get_sink_mapper_factory(&self, name: &str) -> Option<Box<dyn crate::core::extension::SinkMapperFactory>> {
+        self.sink_mapper_factories.read().unwrap().get(name).cloned()
     }
 
     pub fn add_table_factory(&self, name: String, factory: Box<dyn crate::core::extension::TableFactory>) {

--- a/siddhi_rust/src/core/extension/mod.rs
+++ b/siddhi_rust/src/core/extension/mod.rs
@@ -1,6 +1,8 @@
 use std::fmt::Debug;
 use std::sync::{Arc, Mutex};
 
+use crate::core::stream::output::stream_callback::StreamCallback;
+
 use crate::core::config::{siddhi_app_context::SiddhiAppContext, siddhi_query_context::SiddhiQueryContext};
 use crate::core::executor::expression_executor::ExpressionExecutor;
 use crate::core::query::processor::Processor;
@@ -34,6 +36,7 @@ pub trait SourceFactory: Debug + Send + Sync {
 impl Clone for Box<dyn SourceFactory> { fn clone(&self) -> Self { self.clone_box() } }
 
 pub trait SinkFactory: Debug + Send + Sync {
+    fn create(&self) -> Box<dyn StreamCallback>;
     fn clone_box(&self) -> Box<dyn SinkFactory>;
 }
 impl Clone for Box<dyn SinkFactory> { fn clone(&self) -> Self { self.clone_box() } }
@@ -63,3 +66,20 @@ pub trait TableFactory: Debug + Send + Sync {
     fn clone_box(&self) -> Box<dyn TableFactory>;
 }
 impl Clone for Box<dyn TableFactory> { fn clone(&self) -> Self { self.clone_box() } }
+
+#[derive(Debug, Clone)]
+pub struct ExampleSourceFactory;
+
+impl SourceFactory for ExampleSourceFactory {
+    fn clone_box(&self) -> Box<dyn SourceFactory> { Box::new(self.clone()) }
+}
+
+#[derive(Debug, Clone)]
+pub struct LogSinkFactory;
+
+impl SinkFactory for LogSinkFactory {
+    fn create(&self) -> Box<dyn StreamCallback> {
+        Box::new(crate::core::stream::output::LogSink)
+    }
+    fn clone_box(&self) -> Box<dyn SinkFactory> { Box::new(self.clone()) }
+}

--- a/siddhi_rust/src/core/stream/output/mod.rs
+++ b/siddhi_rust/src/core/stream/output/mod.rs
@@ -1,6 +1,7 @@
 // siddhi_rust/src/core/stream/output/mod.rs
 
 pub mod stream_callback;
-// pub mod sink; // For sub-package sink/
+pub mod sink; // For sink implementations
 
-pub use self::stream_callback::{StreamCallback, LogStreamCallback}; // Added LogStreamCallback
+pub use self::stream_callback::{StreamCallback, LogStreamCallback};
+pub use self::sink::LogSink;

--- a/siddhi_rust/src/core/stream/output/sink/log_sink.rs
+++ b/siddhi_rust/src/core/stream/output/sink/log_sink.rs
@@ -1,0 +1,14 @@
+use crate::core::stream::output::stream_callback::StreamCallback;
+use crate::core::event::event::Event;
+use std::fmt::Debug;
+
+#[derive(Debug, Clone)]
+pub struct LogSink;
+
+impl StreamCallback for LogSink {
+    fn receive_events(&self, events: &[Event]) {
+        for e in events {
+            println!("{:?}", e);
+        }
+    }
+}

--- a/siddhi_rust/src/core/stream/output/sink/mod.rs
+++ b/siddhi_rust/src/core/stream/output/sink/mod.rs
@@ -1,0 +1,3 @@
+pub mod log_sink;
+
+pub use log_sink::LogSink;


### PR DESCRIPTION
## Summary
- add example source & sink factories
- register InMemory table factory and example factories by default
- expose getter APIs for all extension factories
- test that QueryParser uses registered factories
- add a simple LogSink to print events

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68497b5dc27c8325b183e6a2f3eca0df