### PR TITLE
Add scheduler and time-window support

### DIFF
--- a/siddhi_rust/src/core/config/siddhi_app_context.rs
+++ b/siddhi_rust/src/core/config/siddhi_app_context.rs
@@ -6,6 +6,7 @@ use std::cell::RefCell;
 use super::siddhi_context::SiddhiContext;
 use crate::core::util::executor_service::ExecutorService;
 use crate::core::util::id_generator::IdGenerator;
+use crate::core::util::Scheduler;
 use std::thread_local;
 // use super::statistics_manager::StatisticsManager; // TODO: Define later
 // use super::timestamp_generator::TimestampGenerator; // TODO: Define later
@@ -58,6 +59,7 @@ pub struct SiddhiAppContext {
     // Threading and scheduling (using placeholders)
     pub executor_service: Option<Arc<ExecutorService>>, // General purpose thread pool for the Siddhi App.
     pub scheduled_executor_service: Option<Arc<crate::core::util::ScheduledExecutorService>>, // Thread pool for scheduled tasks.
+    pub scheduler: Option<Arc<Scheduler>>, // Exposed scheduler for timers
 
     // External references and lifecycle management (using placeholders)
     // pub external_referenced_holders: Vec<ExternalReferencedHolderPlaceholder>, // Manages external resources that need lifecycle management.
@@ -138,6 +140,7 @@ impl SiddhiAppContext {
             statistics_manager: None, // Initialized later in Java
             executor_service: None,
             scheduled_executor_service: None,
+            scheduler: None,
             // external_referenced_holders: Vec::new(),
             // trigger_holders: Vec::new(),
             snapshot_service: None,
@@ -247,6 +250,14 @@ impl SiddhiAppContext {
 
     pub fn set_scheduled_executor_service(&mut self, service: Arc<crate::core::util::ScheduledExecutorService>) {
         self.scheduled_executor_service = Some(service);
+    }
+
+    pub fn get_scheduler(&self) -> Option<Arc<Scheduler>> {
+        self.scheduler.as_ref().cloned()
+    }
+
+    pub fn set_scheduler(&mut self, scheduler: Arc<Scheduler>) {
+        self.scheduler = Some(scheduler);
     }
 
     pub fn get_timestamp_generator(&self) -> &TimestampGeneratorPlaceholder {

--- a/siddhi_rust/src/core/query/processor/stream/window/mod.rs
+++ b/siddhi_rust/src/core/query/processor/stream/window/mod.rs
@@ -5,6 +5,9 @@ use crate::query_api::execution::query::input::handler::WindowHandler;
 use crate::core::extension::WindowProcessorFactory;
 use crate::query_api::expression::{self, constant::ConstantValueWithFloat, Expression};
 use std::sync::{Arc, Mutex};
+use crate::core::util::scheduler::{Scheduler, Schedulable};
+use crate::core::event::stream::stream_event::StreamEvent;
+use crate::core::event::complex_event::ComplexEventType;
 
 pub trait WindowProcessor: Processor {}
 
@@ -77,11 +80,13 @@ impl WindowProcessor for LengthWindowProcessor {}
 pub struct TimeWindowProcessor {
     meta: CommonProcessorMeta,
     pub duration_ms: i64,
+    scheduler: Option<Arc<Scheduler>>,
 }
 
 impl TimeWindowProcessor {
     pub fn new(duration_ms: i64, app_ctx: Arc<SiddhiAppContext>, query_ctx: Arc<SiddhiQueryContext>) -> Self {
-        Self { meta: CommonProcessorMeta::new(app_ctx, query_ctx), duration_ms }
+        let scheduler = app_ctx.get_scheduler();
+        Self { meta: CommonProcessorMeta::new(app_ctx, query_ctx), duration_ms, scheduler }
     }
 
     pub fn from_handler(
@@ -106,9 +111,38 @@ impl TimeWindowProcessor {
     }
 }
 
+#[derive(Debug)]
+struct ExpireTask {
+    event: StreamEvent,
+    next: Option<Arc<Mutex<dyn Processor>>>,
+}
+
+impl Schedulable for ExpireTask {
+    fn on_time(&self, timestamp: i64) {
+        let mut ev = self.event.clone_without_next();
+        ev.set_event_type(ComplexEventType::Expired);
+        ev.set_timestamp(timestamp);
+        if let Some(ref next) = self.next {
+            next.lock().unwrap().process(Some(Box::new(ev)));
+        }
+    }
+}
+
 impl Processor for TimeWindowProcessor {
     fn process(&self, complex_event_chunk: Option<Box<dyn ComplexEvent>>) {
         if let Some(ref next) = self.meta.next_processor {
+            if let Some(ref scheduler) = self.scheduler {
+                if let Some(ref chunk) = complex_event_chunk {
+                    let mut current_opt = Some(chunk.as_ref() as &dyn ComplexEvent);
+                    while let Some(ev) = current_opt {
+                        if let Some(se) = ev.as_any().downcast_ref::<StreamEvent>() {
+                            let task = ExpireTask { event: se.clone_without_next(), next: Some(Arc::clone(next)) };
+                            scheduler.notify_at(se.timestamp + self.duration_ms, Arc::new(task));
+                        }
+                        current_opt = ev.get_next();
+                    }
+                }
+            }
             next.lock().unwrap().process(complex_event_chunk);
         }
     }

--- a/siddhi_rust/src/core/query/selector/select_processor.rs
+++ b/siddhi_rust/src/core/query/selector/select_processor.rs
@@ -126,9 +126,9 @@ impl Processor for SelectProcessor {
 
             // Set the new output data on the event
             current_event_box.set_output_data(Some(new_output_data));
-            // Ensure event type is CURRENT after projection, unless it was a RESET
+            // Preserve original event type unless it is a RESET
             if event_type != ComplexEventType::Reset {
-                 current_event_box.set_event_type(ComplexEventType::Current);
+                 current_event_box.set_event_type(event_type);
             }
             // Timestamp usually remains the same or is explicitly set by a projection.
 

--- a/siddhi_rust/src/core/siddhi_app_runtime_builder.rs
+++ b/siddhi_rust/src/core/siddhi_app_runtime_builder.rs
@@ -101,15 +101,10 @@ impl SiddhiAppRuntimeBuilder {
             self.stream_junction_map.clone(),
         );
 
-        let scheduler = if let Some(exec) = self
+        let scheduler = self
             .siddhi_app_context
-            .get_scheduled_executor_service()
-        {
-            Some(crate::core::util::Scheduler::new(Arc::clone(&exec.executor)))
-        } else {
-            let exec = Arc::new(crate::core::util::ExecutorService::default());
-            Some(crate::core::util::Scheduler::new(exec))
-        };
+            .get_scheduler()
+            .unwrap_or_else(|| Arc::new(crate::core::util::Scheduler::new(Arc::new(crate::core::util::ExecutorService::default()))));
 
         let mut aggregation_map = HashMap::new();
         for (id, _def) in &self.aggregation_definition_map {
@@ -124,7 +119,7 @@ impl SiddhiAppRuntimeBuilder {
             stream_junction_map: self.stream_junction_map,
             input_manager: Arc::new(input_manager),
             query_runtimes: self.query_runtimes,
-            scheduler,
+            scheduler: Some(scheduler),
             aggregation_map,
             // Initialize other runtime fields (tables, windows, partitions, triggers)
             // These would typically be moved from the builder to the runtime instance.

--- a/siddhi_rust/src/core/util/scheduler.rs
+++ b/siddhi_rust/src/core/util/scheduler.rs
@@ -9,7 +9,7 @@ pub trait Schedulable: Send + Sync {
     fn on_time(&self, timestamp: i64);
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Scheduler {
     executor: Arc<ExecutorService>,
 }
@@ -20,7 +20,6 @@ impl Scheduler {
     }
 
     pub fn notify_at(&self, timestamp: i64, target: Arc<dyn Schedulable>) {
-        let exec = Arc::clone(&self.executor);
         self.executor.execute(move || {
             let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis() as i64;
             let delay = if timestamp > now { timestamp - now } else { 0 } as u64;
@@ -30,7 +29,6 @@ impl Scheduler {
     }
 
     pub fn schedule_periodic(&self, period_ms: i64, target: Arc<dyn Schedulable>, limit: Option<usize>) {
-        let exec = Arc::clone(&self.executor);
         self.executor.execute(move || {
             let mut next = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis() as i64 + period_ms;
             let mut count = 0usize;
@@ -47,7 +45,6 @@ impl Scheduler {
 
     pub fn schedule_cron(&self, cron_expr: &str, target: Arc<dyn Schedulable>, limit: Option<usize>) -> Result<(), String> {
         let schedule = Schedule::from_str(cron_expr).map_err(|e| e.to_string())?;
-        let exec = Arc::clone(&self.executor);
         self.executor.execute(move || {
             let iter = schedule.upcoming(Utc);
             let it: Box<dyn Iterator<Item = chrono::DateTime<Utc>>> = match limit {

--- a/siddhi_rust/tests/time_window.rs
+++ b/siddhi_rust/tests/time_window.rs
@@ -1,0 +1,51 @@
+#[path = "common/mod.rs"]
+mod common;
+use siddhi_rust::core::siddhi_manager::SiddhiManager;
+use siddhi_rust::query_compiler::parse;
+use siddhi_rust::core::stream::output::stream_callback::StreamCallback;
+use siddhi_rust::core::event::event::Event;
+use siddhi_rust::core::event::value::AttributeValue;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+#[derive(Debug)]
+struct CollectCallback { events: Arc<Mutex<Vec<Event>>> }
+impl StreamCallback for CollectCallback {
+    fn receive_events(&self, events: &[Event]) {
+        self.events.lock().unwrap().extend_from_slice(events);
+    }
+}
+
+#[test]
+fn test_time_window_expiry() {
+    let app = "\
+        define stream In (v int);\n\
+        define stream Out (v int);\n\
+        from In#time(100) select v insert into Out;\n";
+    let manager = SiddhiManager::new();
+    let api = parse(app).expect("parse");
+    let runtime = manager
+        .create_siddhi_app_runtime_from_api(Arc::new(api), None)
+        .expect("runtime");
+    let collected = Arc::new(Mutex::new(Vec::new()));
+    runtime
+        .add_callback(
+            "Out",
+            Box::new(CollectCallback { events: Arc::clone(&collected) }),
+        )
+        .unwrap();
+    runtime.start();
+    let handler = runtime.get_input_handler("In").unwrap();
+    handler
+        .lock()
+        .unwrap()
+        .send_data(vec![AttributeValue::Int(5)])
+        .unwrap();
+    std::thread::sleep(Duration::from_millis(150));
+    runtime.shutdown();
+    let out = collected.lock().unwrap().clone();
+    println!("events: {:?}", out);
+    assert!(out.len() >= 2);
+    assert_eq!(out[0].data, vec![AttributeValue::Int(5)]);
+    assert!(out.iter().any(|e| e.is_expired));
+}


### PR DESCRIPTION
## Summary
- implement a simple `Scheduler` with callback execution
- expose scheduler via `SiddhiAppContext`
- use scheduler in `TimeWindowProcessor`
- keep event types in `SelectProcessor`
- add a test covering time-window expiry behaviour

## Testing
- `cargo test --quiet`
- `cargo test --test time_window -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_684aacee6b7c83259cdb9bf674a3e92c