### PR TITLE
Implement window buffers with expiration

### DIFF
--- a/siddhi_rust/tests/parser_tests.rs
+++ b/siddhi_rust/tests/parser_tests.rs
@@ -27,7 +27,12 @@ fn test_length_window() {
     runner.send("In", vec![AttributeValue::Int(2)]);
     runner.send("In", vec![AttributeValue::Int(3)]);
     let out = runner.shutdown();
-    assert_eq!(out, vec![vec![AttributeValue::Int(1)], vec![AttributeValue::Int(2)], vec![AttributeValue::Int(3)]]);
+    assert_eq!(out, vec![
+        vec![AttributeValue::Int(1)],
+        vec![AttributeValue::Int(2)],
+        vec![AttributeValue::Int(1)],
+        vec![AttributeValue::Int(3)],
+    ]);
 }
 
 

--- a/siddhi_rust/tests/persistence.rs
+++ b/siddhi_rust/tests/persistence.rs
@@ -89,7 +89,7 @@ fn test_runtime_persist_restore() {
 
     let rev = runtime.persist().unwrap();
     handler.lock().unwrap().send_event_with_timestamp(2, vec![AttributeValue::Int(3)]).unwrap();
-    assert_eq!(*count.lock().unwrap(), 3);
+    assert_eq!(*count.lock().unwrap(), 4);
 
     runtime.restore_revision(&rev).unwrap();
     let restored = svc.snapshot();
@@ -97,5 +97,5 @@ fn test_runtime_persist_restore() {
     *count.lock().unwrap() = restored_val;
 
     handler.lock().unwrap().send_event_with_timestamp(3, vec![AttributeValue::Int(4)]).unwrap();
-    assert_eq!(*count.lock().unwrap(), 3);
+    assert_eq!(*count.lock().unwrap(), 4);
 }

--- a/siddhi_rust/tests/window_queries.rs
+++ b/siddhi_rust/tests/window_queries.rs
@@ -11,6 +11,12 @@ use siddhi_rust::query_api::definition::attribute::Type as AttrType;
 use siddhi_rust::query_api::expression::Expression;
 use std::sync::{Arc, Mutex};
 use std::collections::HashMap;
+use siddhi_rust::core::siddhi_manager::SiddhiManager;
+use siddhi_rust::query_compiler::parse;
+use siddhi_rust::core::stream::output::stream_callback::StreamCallback;
+use siddhi_rust::core::event::event::Event;
+use siddhi_rust::core::event::value::AttributeValue;
+use std::time::Duration;
 
 fn setup_context() -> (Arc<SiddhiAppContext>, HashMap<String, Arc<Mutex<StreamJunction>>>) {
     let siddhi_context = Arc::new(SiddhiContext::new());
@@ -28,6 +34,15 @@ fn setup_context() -> (Arc<SiddhiAppContext>, HashMap<String, Arc<Mutex<StreamJu
     map.insert("OutStream".to_string(), out_junction);
 
     (app_ctx, map)
+}
+
+#[derive(Debug)]
+struct CollectEvents { events: Arc<Mutex<Vec<Event>>> }
+
+impl StreamCallback for CollectEvents {
+    fn receive_events(&self, events: &[Event]) {
+        self.events.lock().unwrap().extend_from_slice(events);
+    }
 }
 
 #[test]
@@ -58,5 +73,68 @@ fn test_time_window_query_parse() {
 
     let res = QueryParser::parse_query(&query, &app_ctx, &junctions, &HashMap::new());
     assert!(res.is_ok());
+}
+
+#[test]
+fn test_length_window_runtime() {
+    let app = "\
+        define stream In (v int);\n\
+        define stream Out (v int);\n\
+        from In#length(2) select v insert into Out;\n";
+    let manager = SiddhiManager::new();
+    let api = parse(app).expect("parse");
+    let runtime = manager
+        .create_siddhi_app_runtime_from_api(Arc::new(api), None)
+        .expect("runtime");
+    let collected = Arc::new(Mutex::new(Vec::new()));
+    runtime
+        .add_callback(
+            "Out",
+            Box::new(CollectEvents { events: Arc::clone(&collected) }),
+        )
+        .unwrap();
+    runtime.start();
+    let handler = runtime.get_input_handler("In").unwrap();
+    handler.lock().unwrap().send_data(vec![AttributeValue::Int(1)]).unwrap();
+    handler.lock().unwrap().send_data(vec![AttributeValue::Int(2)]).unwrap();
+    handler.lock().unwrap().send_data(vec![AttributeValue::Int(3)]).unwrap();
+    std::thread::sleep(Duration::from_millis(50));
+    runtime.shutdown();
+    let out = collected.lock().unwrap().clone();
+    assert_eq!(out.len(), 4);
+    assert_eq!(out[0].data, vec![AttributeValue::Int(1)]);
+    assert_eq!(out[1].data, vec![AttributeValue::Int(2)]);
+    assert!(out[2].is_expired);
+    assert_eq!(out[2].data, vec![AttributeValue::Int(1)]);
+    assert_eq!(out[3].data, vec![AttributeValue::Int(3)]);
+}
+
+#[test]
+fn test_time_window_runtime() {
+    let app = "\
+        define stream In (v int);\n\
+        define stream Out (v int);\n\
+        from In#time(100) select v insert into Out;\n";
+    let manager = SiddhiManager::new();
+    let api = parse(app).expect("parse");
+    let runtime = manager
+        .create_siddhi_app_runtime_from_api(Arc::new(api), None)
+        .expect("runtime");
+    let collected = Arc::new(Mutex::new(Vec::new()));
+    runtime
+        .add_callback(
+            "Out",
+            Box::new(CollectEvents { events: Arc::clone(&collected) }),
+        )
+        .unwrap();
+    runtime.start();
+    let handler = runtime.get_input_handler("In").unwrap();
+    handler.lock().unwrap().send_data(vec![AttributeValue::Int(5)]).unwrap();
+    std::thread::sleep(Duration::from_millis(150));
+    runtime.shutdown();
+    let out = collected.lock().unwrap().clone();
+    assert!(out.len() >= 2);
+    assert_eq!(out[0].data, vec![AttributeValue::Int(5)]);
+    assert!(out.iter().any(|e| e.is_expired));
 }
 


### PR DESCRIPTION
## Summary
- support internal buffers in length and time windows
- emit expired events using scheduler
- adjust persistence & parser tests
- add runtime window tests

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684ab3feb61883258dc2eb4dc3176bbf