### PR TITLE
Implement logical pattern runtime

### DIFF
--- a/siddhi_rust/src/core/query/input/stream/state/logical_processor.rs
+++ b/siddhi_rust/src/core/query/input/stream/state/logical_processor.rs
@@ -1,0 +1,169 @@
+use std::sync::{Arc, Mutex};
+
+use crate::core::config::siddhi_app_context::SiddhiAppContext;
+use crate::core::config::siddhi_query_context::SiddhiQueryContext;
+use crate::core::event::complex_event::ComplexEvent;
+use crate::core::event::stream::stream_event::StreamEvent;
+use crate::core::event::value::AttributeValue;
+use crate::core::query::processor::{CommonProcessorMeta, ProcessingMode, Processor};
+use super::sequence_processor::SequenceSide;
+
+#[derive(Debug, Clone, Copy)]
+pub enum LogicalType {
+    And,
+    Or,
+}
+
+#[derive(Debug)]
+pub struct LogicalProcessor {
+    meta: CommonProcessorMeta,
+    pub logical_type: LogicalType,
+    pub first_buffer: Vec<StreamEvent>,
+    pub second_buffer: Vec<StreamEvent>,
+    pub first_attr_count: usize,
+    pub second_attr_count: usize,
+    pub next_processor: Option<Arc<Mutex<dyn Processor>>>,
+}
+
+impl LogicalProcessor {
+    pub fn new(
+        logical_type: LogicalType,
+        first_attr_count: usize,
+        second_attr_count: usize,
+        app_ctx: Arc<SiddhiAppContext>,
+        query_ctx: Arc<SiddhiQueryContext>,
+    ) -> Self {
+        Self {
+            meta: CommonProcessorMeta::new(app_ctx, query_ctx),
+            logical_type,
+            first_buffer: Vec::new(),
+            second_buffer: Vec::new(),
+            first_attr_count,
+            second_attr_count,
+            next_processor: None,
+        }
+    }
+
+    fn build_joined_event(
+        &self,
+        first: Option<&StreamEvent>,
+        second: Option<&StreamEvent>,
+    ) -> StreamEvent {
+        let mut event = StreamEvent::new(
+            second.map(|s| s.timestamp).unwrap_or_else(|| first.unwrap().timestamp),
+            self.first_attr_count + self.second_attr_count,
+            0,
+            0,
+        );
+        for i in 0..self.first_attr_count {
+            let val = first
+                .and_then(|f| f.before_window_data.get(i).cloned())
+                .unwrap_or(AttributeValue::Null);
+            event.before_window_data[i] = val;
+        }
+        for j in 0..self.second_attr_count {
+            let val = second
+                .and_then(|s| s.before_window_data.get(j).cloned())
+                .unwrap_or(AttributeValue::Null);
+            event.before_window_data[self.first_attr_count + j] = val;
+        }
+        event
+    }
+
+    fn forward(&self, se: StreamEvent) {
+        if let Some(ref next) = self.next_processor {
+            next.lock().unwrap().process(Some(Box::new(se)));
+        }
+    }
+
+    fn try_produce(&mut self) {
+        match self.logical_type {
+            LogicalType::And => {
+                while !self.first_buffer.is_empty() && !self.second_buffer.is_empty() {
+                    let first = self.first_buffer.remove(0);
+                    let second = self.second_buffer.remove(0);
+                    let joined = self.build_joined_event(Some(&first), Some(&second));
+                    self.forward(joined);
+                }
+            }
+            LogicalType::Or => {
+                while !self.first_buffer.is_empty() {
+                    let first = self.first_buffer.remove(0);
+                    let joined = self.build_joined_event(Some(&first), None);
+                    self.forward(joined);
+                }
+                while !self.second_buffer.is_empty() {
+                    let second = self.second_buffer.remove(0);
+                    let joined = self.build_joined_event(None, Some(&second));
+                    self.forward(joined);
+                }
+            }
+        }
+    }
+
+    fn process_event(&mut self, side: SequenceSide, mut chunk: Option<Box<dyn ComplexEvent>>) {
+        while let Some(mut ce) = chunk {
+            chunk = ce.set_next(None);
+            if let Some(se) = ce.as_any().downcast_ref::<StreamEvent>() {
+                let se_clone = se.clone_without_next();
+                match side {
+                    SequenceSide::First => {
+                        self.first_buffer.push(se_clone);
+                    }
+                    SequenceSide::Second => {
+                        self.second_buffer.push(se_clone);
+                    }
+                }
+                self.try_produce();
+            }
+        }
+    }
+
+    pub fn create_side_processor(self_arc: &Arc<Mutex<Self>>, side: SequenceSide) -> Arc<Mutex<LogicalProcessorSide>> {
+        Arc::new(Mutex::new(LogicalProcessorSide {
+            parent: Arc::clone(self_arc),
+            side,
+        }))
+    }
+}
+
+#[derive(Debug)]
+pub struct LogicalProcessorSide {
+    parent: Arc<Mutex<LogicalProcessor>>,
+    side: SequenceSide,
+}
+
+impl Processor for LogicalProcessorSide {
+    fn process(&self, chunk: Option<Box<dyn ComplexEvent>>) {
+        self.parent.lock().unwrap().process_event(self.side, chunk);
+    }
+
+    fn next_processor(&self) -> Option<Arc<Mutex<dyn Processor>>> {
+        self.parent.lock().unwrap().next_processor.clone()
+    }
+
+    fn set_next_processor(&mut self, next: Option<Arc<Mutex<dyn Processor>>>) {
+        self.parent.lock().unwrap().next_processor = next;
+    }
+
+    fn clone_processor(&self, ctx: &Arc<SiddhiQueryContext>) -> Box<dyn Processor> {
+        let parent = self.parent.lock().unwrap();
+        let cloned = LogicalProcessor::new(
+            parent.logical_type,
+            parent.first_attr_count,
+            parent.second_attr_count,
+            Arc::clone(&parent.meta.siddhi_app_context),
+            Arc::clone(ctx),
+        );
+        let arc = Arc::new(Mutex::new(cloned));
+        Box::new(LogicalProcessorSide { parent: arc, side: self.side })
+    }
+
+    fn get_siddhi_app_context(&self) -> Arc<SiddhiAppContext> {
+        self.parent.lock().unwrap().meta.siddhi_app_context.clone()
+    }
+
+    fn get_processing_mode(&self) -> ProcessingMode { ProcessingMode::DEFAULT }
+
+    fn is_stateful(&self) -> bool { true }
+}

--- a/siddhi_rust/src/core/query/input/stream/state/mod.rs
+++ b/siddhi_rust/src/core/query/input/stream/state/mod.rs
@@ -1,3 +1,5 @@
 pub mod sequence_processor;
+pub mod logical_processor;
 
 pub use sequence_processor::{SequenceProcessor, SequenceProcessorSide, SequenceType, SequenceSide};
+pub use logical_processor::{LogicalProcessor, LogicalProcessorSide, LogicalType};

--- a/siddhi_rust/tests/pattern_runtime.rs
+++ b/siddhi_rust/tests/pattern_runtime.rs
@@ -78,3 +78,115 @@ fn test_sequence_runtime_processing() {
     assert_eq!(events[1].data[0], CoreAttributeValue::Int(3));
     assert_eq!(events[1].data[1], CoreAttributeValue::Int(4));
 }
+
+#[test]
+fn test_every_sequence() {
+    let siddhi_context = Arc::new(SiddhiContext::new());
+    let mut app = ApiSiddhiApp::new("TestApp2".to_string());
+
+    let a_def = StreamDefinition::new("AStream".to_string()).attribute("val".to_string(), AttrType::INT);
+    let b_def = StreamDefinition::new("BStream".to_string()).attribute("val".to_string(), AttrType::INT);
+    let out_def = StreamDefinition::new("OutStream".to_string())
+        .attribute("aval".to_string(), AttrType::INT)
+        .attribute("bval".to_string(), AttrType::INT);
+    app.stream_definition_map.insert("AStream".to_string(), Arc::new(a_def));
+    app.stream_definition_map.insert("BStream".to_string(), Arc::new(b_def));
+    app.stream_definition_map.insert("OutStream".to_string(), Arc::new(out_def));
+
+    let a_si = SingleInputStream::new_basic("AStream".to_string(), false, false, None, Vec::new());
+    let b_si = SingleInputStream::new_basic("BStream".to_string(), false, false, None, Vec::new());
+    let sse1 = State::stream(a_si);
+    let sse2 = State::stream(b_si);
+    let next = State::next(State::every(StateElement::Stream(sse1)), StateElement::Stream(sse2));
+    let state_stream = StateInputStream::sequence_stream(next, None);
+    let input = InputStream::State(Box::new(state_stream));
+
+    let mut selector = Selector::new();
+    selector.selection_list = vec![
+        OutputAttribute::new(Some("aval".to_string()), Expression::variable("val".to_string())),
+        OutputAttribute::new(Some("bval".to_string()), Expression::Variable(
+            siddhi_rust::query_api::expression::variable::Variable::new("val".to_string()).of_stream("BStream".to_string())
+        )),
+    ];
+
+    let insert_action = InsertIntoStreamAction { target_id: "OutStream".to_string(), is_inner_stream: false, is_fault_stream: false };
+    let out_stream = OutputStream::new(OutputStreamAction::InsertInto(insert_action), None);
+    let query = Query::query().from(input).select(selector).out_stream(out_stream);
+    app.execution_element_list.push(ExecutionElement::Query(query));
+
+    let app = Arc::new(app);
+    let runtime = SiddhiAppRuntime::new(Arc::clone(&app), siddhi_context).expect("runtime");
+    let collected = Arc::new(Mutex::new(Vec::new()));
+    runtime.add_callback("OutStream", Box::new(CollectCallback::new(Arc::clone(&collected)))).unwrap();
+    runtime.start();
+    let a_handler = runtime.get_input_handler("AStream").unwrap();
+    let b_handler = runtime.get_input_handler("BStream").unwrap();
+
+    a_handler.lock().unwrap().send_event_with_timestamp(0, vec![CoreAttributeValue::Int(1)]).unwrap();
+    b_handler.lock().unwrap().send_event_with_timestamp(1, vec![CoreAttributeValue::Int(2)]).unwrap();
+    a_handler.lock().unwrap().send_event_with_timestamp(2, vec![CoreAttributeValue::Int(3)]).unwrap();
+    b_handler.lock().unwrap().send_event_with_timestamp(3, vec![CoreAttributeValue::Int(4)]).unwrap();
+
+    runtime.shutdown();
+
+    let events = collected.lock().unwrap();
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[0].data[0], CoreAttributeValue::Int(1));
+    assert_eq!(events[0].data[1], CoreAttributeValue::Int(2));
+    assert_eq!(events[1].data[0], CoreAttributeValue::Int(3));
+    assert_eq!(events[1].data[1], CoreAttributeValue::Int(4));
+}
+
+#[test]
+fn test_logical_and_pattern() {
+    let siddhi_context = Arc::new(SiddhiContext::new());
+    let mut app = ApiSiddhiApp::new("TestApp3".to_string());
+
+    let a_def = StreamDefinition::new("AStream".to_string()).attribute("val".to_string(), AttrType::INT);
+    let b_def = StreamDefinition::new("BStream".to_string()).attribute("val".to_string(), AttrType::INT);
+    let out_def = StreamDefinition::new("OutStream".to_string())
+        .attribute("aval".to_string(), AttrType::INT)
+        .attribute("bval".to_string(), AttrType::INT);
+    app.stream_definition_map.insert("AStream".to_string(), Arc::new(a_def));
+    app.stream_definition_map.insert("BStream".to_string(), Arc::new(b_def));
+    app.stream_definition_map.insert("OutStream".to_string(), Arc::new(out_def));
+
+    let a_si = SingleInputStream::new_basic("AStream".to_string(), false, false, None, Vec::new());
+    let b_si = SingleInputStream::new_basic("BStream".to_string(), false, false, None, Vec::new());
+    let sse1 = State::stream(a_si);
+    let sse2 = State::stream(b_si);
+    let logical = State::logical_and(sse1, sse2);
+    let state_stream = StateInputStream::pattern_stream(logical, None);
+    let input = InputStream::State(Box::new(state_stream));
+
+    let mut selector = Selector::new();
+    selector.selection_list = vec![
+        OutputAttribute::new(Some("aval".to_string()), Expression::variable("val".to_string())),
+        OutputAttribute::new(Some("bval".to_string()), Expression::Variable(
+            siddhi_rust::query_api::expression::variable::Variable::new("val".to_string()).of_stream("BStream".to_string())
+        )),
+    ];
+
+    let insert_action = InsertIntoStreamAction { target_id: "OutStream".to_string(), is_inner_stream: false, is_fault_stream: false };
+    let out_stream = OutputStream::new(OutputStreamAction::InsertInto(insert_action), None);
+    let query = Query::query().from(input).select(selector).out_stream(out_stream);
+    app.execution_element_list.push(ExecutionElement::Query(query));
+
+    let app = Arc::new(app);
+    let runtime = SiddhiAppRuntime::new(Arc::clone(&app), siddhi_context).expect("runtime");
+    let collected = Arc::new(Mutex::new(Vec::new()));
+    runtime.add_callback("OutStream", Box::new(CollectCallback::new(Arc::clone(&collected)))).unwrap();
+    runtime.start();
+    let a_handler = runtime.get_input_handler("AStream").unwrap();
+    let b_handler = runtime.get_input_handler("BStream").unwrap();
+
+    a_handler.lock().unwrap().send_event_with_timestamp(0, vec![CoreAttributeValue::Int(1)]).unwrap();
+    b_handler.lock().unwrap().send_event_with_timestamp(1, vec![CoreAttributeValue::Int(2)]).unwrap();
+
+    runtime.shutdown();
+
+    let events = collected.lock().unwrap();
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].data[0], CoreAttributeValue::Int(1));
+    assert_eq!(events[0].data[1], CoreAttributeValue::Int(2));
+}


### PR DESCRIPTION
## Summary
- implement `LogicalProcessor` for pattern state combinations
- extend `QueryParser` to parse logical and every states
- update tests for new pattern behaviors

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684addd9854c83258c3b611eedfaa9ae