### PR TITLE
Add table query operations

### DIFF
--- a/siddhi_rust/src/query_compiler/grammar.lalrpop
+++ b/siddhi_rust/src/query_compiler/grammar.lalrpop
@@ -9,7 +9,13 @@ use crate::query_api::definition::attribute::Attribute;
 use crate::query_api::execution::query::input::handler::WindowHandler;
 use crate::query_api::execution::query::{Query};
 use crate::query_api::execution::query::selection::Selector;
-use crate::query_api::execution::query::output::output_stream::{OutputStream, OutputStreamAction, InsertIntoStreamAction};
+use crate::query_api::execution::query::output::output_stream::{
+    OutputStream,
+    OutputStreamAction,
+    InsertIntoStreamAction,
+    UpdateStreamAction,
+    DeleteStreamAction,
+};
 use crate::query_api::execution::query::input::{
     InputStream, SingleInputStream, JoinType, StateInputStreamType, StateElement, State,
 };
@@ -202,6 +208,23 @@ BasicUnit: StateElement = {
 };
 
 pub QueryStmt: Query = {
+    // INSERT INTO <stream/table>
+    "from" <istream:InputStreamRule> "select" <sel:SelectList> "insert" "into" "table" <out_id:Ident> => {
+        let in_stream = istream;
+        let mut selector = Selector::new();
+        for (expr, alias) in sel {
+            match alias {
+                Some(a) => selector = selector.select(a, expr),
+                None => match expr.clone() {
+                    Expression::Variable(var) => selector = selector.select_variable(var),
+                    _ => selector = selector.select(String::new(), expr),
+                },
+            }
+        }
+        let insert_action = InsertIntoStreamAction { target_id: out_id, is_inner_stream: false, is_fault_stream: false };
+        let output_stream = OutputStream::new(OutputStreamAction::InsertInto(insert_action), None);
+        Query::query().from(in_stream).select(selector).out_stream(output_stream)
+    },
     "from" <istream:InputStreamRule> "select" <sel:SelectList> "insert" "into" <out_id:Ident> => {
         let in_stream = istream;
         let mut selector = Selector::new();
@@ -216,6 +239,40 @@ pub QueryStmt: Query = {
         }
         let insert_action = InsertIntoStreamAction { target_id: out_id, is_inner_stream: false, is_fault_stream: false };
         let output_stream = OutputStream::new(OutputStreamAction::InsertInto(insert_action), None);
+        Query::query().from(in_stream).select(selector).out_stream(output_stream)
+    },
+    // UPDATE TABLE
+    "from" <istream:InputStreamRule> "select" <sel:SelectList> "update" "table" <t_id:Ident> => {
+        let in_stream = istream;
+        let mut selector = Selector::new();
+        for (expr, alias) in sel {
+            match alias {
+                Some(a) => selector = selector.select(a, expr),
+                None => match expr.clone() {
+                    Expression::Variable(var) => selector = selector.select_variable(var),
+                    _ => selector = selector.select(String::new(), expr),
+                },
+            }
+        }
+        let update_action = UpdateStreamAction { target_id: t_id, on_update_expression: Expression::value_bool(true), update_set_clause: None };
+        let output_stream = OutputStream::new(OutputStreamAction::Update(update_action), None);
+        Query::query().from(in_stream).select(selector).out_stream(output_stream)
+    },
+    // DELETE FROM TABLE
+    "from" <istream:InputStreamRule> "select" <sel:SelectList> "delete" "table" <t_id:Ident> => {
+        let in_stream = istream;
+        let mut selector = Selector::new();
+        for (expr, alias) in sel {
+            match alias {
+                Some(a) => selector = selector.select(a, expr),
+                None => match expr.clone() {
+                    Expression::Variable(var) => selector = selector.select_variable(var),
+                    _ => selector = selector.select(String::new(), expr),
+                },
+            }
+        }
+        let delete_action = DeleteStreamAction { target_id: t_id, on_delete_expression: Expression::value_bool(true) };
+        let output_stream = OutputStream::new(OutputStreamAction::Delete(delete_action), None);
         Query::query().from(in_stream).select(selector).out_stream(output_stream)
     }
 };

--- a/siddhi_rust/tests/table_ops.rs
+++ b/siddhi_rust/tests/table_ops.rs
@@ -10,6 +10,39 @@ use siddhi_rust::core::config::siddhi_query_context::SiddhiQueryContext;
 use siddhi_rust::core::config::siddhi_context::SiddhiContext;
 use siddhi_rust::core::event::value::AttributeValue;
 use std::sync::Arc;
+use siddhi_rust::core::table::JdbcTable;
+use siddhi_rust::core::persistence::data_source::{DataSource, DataSourceConfig};
+use rusqlite::Connection;
+use std::sync::Mutex;
+use std::any::Any;
+
+#[derive(Debug)]
+struct SqliteDataSource { conn: Arc<Mutex<Connection>> }
+
+impl SqliteDataSource {
+    fn new(path: &str) -> Self {
+        Self { conn: Arc::new(Mutex::new(Connection::open(path).unwrap())) }
+    }
+}
+
+impl DataSource for SqliteDataSource {
+    fn get_type(&self) -> String { "sqlite".to_string() }
+    fn init(&mut self, _ctx: &Arc<SiddhiAppContext>, _id: &str, _cfg: DataSourceConfig) -> Result<(), String> { Ok(()) }
+    fn get_connection(&self) -> Result<Box<dyn Any>, String> {
+        Ok(Box::new(self.conn.clone()) as Box<dyn Any>)
+    }
+    fn shutdown(&mut self) -> Result<(), String> { Ok(()) }
+    fn clone_data_source(&self) -> Box<dyn DataSource> { Box::new(SqliteDataSource { conn: self.conn.clone() }) }
+}
+
+fn setup_jdbc_table(ctx: &Arc<SiddhiContext>, table_name: &str) {
+    let ds = ctx.get_data_source("DS1").unwrap();
+    let conn_any = ds.get_connection().unwrap();
+    let conn_arc = conn_any.downcast::<Arc<Mutex<Connection>>>().unwrap();
+    let mut conn = conn_arc.lock().unwrap();
+    let sql = format!("CREATE TABLE {} (c0 TEXT)", table_name);
+    conn.execute(&sql, []).unwrap();
+}
 
 #[test]
 fn test_table_input_handler_add() {
@@ -42,4 +75,85 @@ fn test_insert_into_table_processor() {
     se.set_output_data(Some(vec![AttributeValue::Int(7)]));
     proc.process(Some(Box::new(se)));
     assert!(app_ctx.get_siddhi_context().get_table("T2").unwrap().contains(&[AttributeValue::Int(7)]));
+}
+
+#[test]
+fn test_table_input_handler_update_delete_find() {
+    let ctx = Arc::new(SiddhiAppContext::new(
+        Arc::new(SiddhiContext::default()),
+        "app".to_string(),
+        Arc::new(siddhi_rust::query_api::siddhi_app::SiddhiApp::new("app".to_string())),
+        String::new(),
+    ));
+    let table: Arc<dyn Table> = Arc::new(InMemoryTable::new());
+    ctx.get_siddhi_context().add_table("T3".to_string(), table.clone());
+    let handler = TableInputHandler::new(table.clone(), Arc::clone(&ctx));
+    handler.add(vec![Event::new_with_data(0, vec![AttributeValue::String("a".into())])]);
+    assert!(table.contains(&[AttributeValue::String("a".into())]));
+    assert!(handler.update(vec![AttributeValue::String("a".into())], vec![AttributeValue::String("b".into())]));
+    assert!(table.contains(&[AttributeValue::String("b".into())]));
+    assert!(handler.delete(vec![AttributeValue::String("b".into())]));
+    assert!(!table.contains(&[AttributeValue::String("b".into())]));
+    handler.add(vec![Event::new_with_data(0, vec![AttributeValue::String("x".into())])]);
+    assert_eq!(table.find(&[AttributeValue::String("x".into())]), Some(vec![AttributeValue::String("x".into())]));
+}
+
+#[test]
+fn test_table_input_handler_jdbc() {
+    let ctx = Arc::new(SiddhiContext::new());
+    ctx.add_data_source("DS1".to_string(), Arc::new(SqliteDataSource::new(":memory:")));
+    setup_jdbc_table(&ctx, "test2");
+
+    let app_ctx = Arc::new(SiddhiAppContext::new(
+        Arc::clone(&ctx),
+        "app".to_string(),
+        Arc::new(siddhi_rust::query_api::siddhi_app::SiddhiApp::new("app".to_string())),
+        String::new(),
+    ));
+    let table: Arc<dyn Table> = Arc::new(JdbcTable::new("test2".to_string(), "DS1".to_string(), Arc::clone(&ctx)).unwrap());
+    app_ctx.get_siddhi_context().add_table("J1".to_string(), table.clone());
+    let handler = TableInputHandler::new(table.clone(), Arc::clone(&app_ctx));
+
+    handler.add(vec![Event::new_with_data(0, vec![AttributeValue::String("a".into())])]);
+    assert!(table.contains(&[AttributeValue::String("a".into())]));
+    assert!(handler.update(vec![AttributeValue::String("a".into())], vec![AttributeValue::String("b".into())]));
+    assert!(table.contains(&[AttributeValue::String("b".into())]));
+    assert!(handler.delete(vec![AttributeValue::String("b".into())]));
+    assert!(!table.contains(&[AttributeValue::String("b".into())]));
+}
+
+#[test]
+fn test_query_parser_with_table_actions() {
+    use siddhi_rust::query_compiler::{parse_query, parse_stream_definition};
+    use siddhi_rust::core::stream::stream_junction::StreamJunction;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    let s_def = Arc::new(parse_stream_definition("define stream S (val string)").unwrap());
+    let t_def = Arc::new(siddhi_rust::query_compiler::parse_table_definition("define table T (val string)").unwrap());
+    let app_ctx = Arc::new(SiddhiAppContext::new(
+        Arc::new(SiddhiContext::default()),
+        "app".to_string(),
+        Arc::new(siddhi_rust::query_api::siddhi_app::SiddhiApp::new("app".to_string())),
+        String::new(),
+    ));
+    app_ctx.get_siddhi_context().add_table("T".to_string(), Arc::new(InMemoryTable::new()));
+
+    let mut junctions = HashMap::new();
+    junctions.insert(
+        "S".to_string(),
+        Arc::new(Mutex::new(StreamJunction::new("S".to_string(), Arc::clone(&s_def), Arc::clone(&app_ctx), 1024, false, None))),
+    );
+
+    let mut table_defs = HashMap::new();
+    table_defs.insert("T".to_string(), t_def);
+
+    let q1 = parse_query("from S select val insert into table T").unwrap();
+    assert!(siddhi_rust::core::util::parser::QueryParser::parse_query(&q1, &app_ctx, &junctions, &table_defs).is_ok());
+
+    let q2 = parse_query("from S select val update table T").unwrap();
+    assert!(siddhi_rust::core::util::parser::QueryParser::parse_query(&q2, &app_ctx, &junctions, &table_defs).is_ok());
+
+    let q3 = parse_query("from S select val delete table T").unwrap();
+    assert!(siddhi_rust::core::util::parser::QueryParser::parse_query(&q3, &app_ctx, &junctions, &table_defs).is_ok());
 }


### PR DESCRIPTION
## Summary
- enable update/delete output actions via `QueryParser`
- extend grammar to parse `insert/update/delete table` syntax
- test TableInputHandler for both `InMemoryTable` and `JdbcTable`
- verify query parsing for table actions

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684ae49c37f8832585100afad6df332a