### PR TITLE
Add basic source/sink framework

### DIFF
--- a/siddhi_rust/src/core/config/siddhi_context.rs
+++ b/siddhi_rust/src/core/config/siddhi_context.rs
@@ -294,7 +294,7 @@ impl SiddhiContext {
             MinForeverAttributeAggregatorFactory, MaxForeverAttributeAggregatorFactory,
         };
         use crate::core::table::InMemoryTableFactory;
-        use crate::core::extension::{LogSinkFactory, ExampleSourceFactory};
+        use crate::core::extension::{LogSinkFactory, TimerSourceFactory};
 
         self.add_window_factory("length".to_string(), Box::new(LengthWindowFactory));
         self.add_window_factory("time".to_string(), Box::new(TimeWindowFactory));
@@ -309,7 +309,7 @@ impl SiddhiContext {
         self.add_attribute_aggregator_factory("maxForever".to_string(), Box::new(MaxForeverAttributeAggregatorFactory));
 
         self.add_table_factory("inMemory".to_string(), Box::new(InMemoryTableFactory));
-        self.add_source_factory("example".to_string(), Box::new(ExampleSourceFactory));
+        self.add_source_factory("timer".to_string(), Box::new(TimerSourceFactory));
         self.add_sink_factory("log".to_string(), Box::new(LogSinkFactory));
     }
 

--- a/siddhi_rust/src/core/extension/mod.rs
+++ b/siddhi_rust/src/core/extension/mod.rs
@@ -31,12 +31,13 @@ impl Clone for Box<dyn AttributeAggregatorFactory> {
 }
 
 pub trait SourceFactory: Debug + Send + Sync {
+    fn create(&self) -> Box<dyn crate::core::stream::input::source::Source>;
     fn clone_box(&self) -> Box<dyn SourceFactory>;
 }
 impl Clone for Box<dyn SourceFactory> { fn clone(&self) -> Self { self.clone_box() } }
 
 pub trait SinkFactory: Debug + Send + Sync {
-    fn create(&self) -> Box<dyn StreamCallback>;
+    fn create(&self) -> Box<dyn crate::core::stream::output::sink::Sink>;
     fn clone_box(&self) -> Box<dyn SinkFactory>;
 }
 impl Clone for Box<dyn SinkFactory> { fn clone(&self) -> Self { self.clone_box() } }
@@ -68,9 +69,12 @@ pub trait TableFactory: Debug + Send + Sync {
 impl Clone for Box<dyn TableFactory> { fn clone(&self) -> Self { self.clone_box() } }
 
 #[derive(Debug, Clone)]
-pub struct ExampleSourceFactory;
+pub struct TimerSourceFactory;
 
-impl SourceFactory for ExampleSourceFactory {
+impl SourceFactory for TimerSourceFactory {
+    fn create(&self) -> Box<dyn crate::core::stream::input::source::Source> {
+        Box::new(crate::core::stream::input::source::timer_source::TimerSource::new(1000))
+    }
     fn clone_box(&self) -> Box<dyn SourceFactory> { Box::new(self.clone()) }
 }
 
@@ -78,8 +82,8 @@ impl SourceFactory for ExampleSourceFactory {
 pub struct LogSinkFactory;
 
 impl SinkFactory for LogSinkFactory {
-    fn create(&self) -> Box<dyn StreamCallback> {
-        Box::new(crate::core::stream::output::LogSink)
+    fn create(&self) -> Box<dyn crate::core::stream::output::sink::Sink> {
+        Box::new(crate::core::stream::output::sink::LogSink::new())
     }
     fn clone_box(&self) -> Box<dyn SinkFactory> { Box::new(self.clone()) }
 }

--- a/siddhi_rust/src/core/stream/input/mod.rs
+++ b/siddhi_rust/src/core/stream/input/mod.rs
@@ -5,7 +5,7 @@ pub mod input_manager;
 pub mod input_distributor;
 pub mod input_entry_valve;
 pub mod table_input_handler;
-// pub mod source; // For sub-package source/
+pub mod source; // For sub-package source/
 
 pub use self::input_handler::InputHandler;
 pub use self::input_manager::InputManager;

--- a/siddhi_rust/src/core/stream/input/source/mod.rs
+++ b/siddhi_rust/src/core/stream/input/source/mod.rs
@@ -1,0 +1,15 @@
+pub mod timer_source;
+
+use crate::core::stream::input::input_handler::InputHandler;
+use std::sync::{Arc, Mutex};
+use std::fmt::Debug;
+
+pub trait Source: Debug + Send + Sync {
+    fn start(&mut self, handler: Arc<Mutex<InputHandler>>);
+    fn stop(&mut self);
+    fn clone_box(&self) -> Box<dyn Source>;
+}
+
+impl Clone for Box<dyn Source> {
+    fn clone(&self) -> Self { self.clone_box() }
+}

--- a/siddhi_rust/src/core/stream/input/source/timer_source.rs
+++ b/siddhi_rust/src/core/stream/input/source/timer_source.rs
@@ -1,0 +1,45 @@
+use super::Source;
+use crate::core::stream::input::input_handler::InputHandler;
+use crate::core::event::event::Event;
+use crate::core::event::value::AttributeValue;
+use std::sync::{Arc, Mutex, atomic::{AtomicBool, Ordering}};
+use std::thread;
+use std::time::Duration;
+use std::fmt::Debug;
+
+#[derive(Debug, Clone)]
+pub struct TimerSource {
+    interval_ms: u64,
+    running: Arc<AtomicBool>,
+}
+
+impl TimerSource {
+    pub fn new(interval_ms: u64) -> Self {
+        Self { interval_ms, running: Arc::new(AtomicBool::new(false)) }
+    }
+}
+
+impl Source for TimerSource {
+    fn start(&mut self, handler: Arc<Mutex<InputHandler>>) {
+        let running = self.running.clone();
+        running.store(true, Ordering::SeqCst);
+        let interval = self.interval_ms;
+        thread::spawn(move || {
+            while running.load(Ordering::SeqCst) {
+                let event = Event::new_with_data(0, vec![AttributeValue::String("tick".to_string())]);
+                if let Ok(mut h) = handler.lock() {
+                    let _ = h.send_single_event(event);
+                }
+                thread::sleep(Duration::from_millis(interval));
+            }
+        });
+    }
+
+    fn stop(&mut self) {
+        self.running.store(false, Ordering::SeqCst);
+    }
+
+    fn clone_box(&self) -> Box<dyn Source> {
+        Box::new(self.clone())
+    }
+}

--- a/siddhi_rust/src/core/stream/mod.rs
+++ b/siddhi_rust/src/core/stream/mod.rs
@@ -3,7 +3,6 @@ pub mod input;
 pub mod output;
 
 pub use self::stream_junction::{StreamJunction, OnErrorAction, Receiver as StreamJunctionReceiver, Publisher};
-pub use self::input::InputHandler; // Re-exporting key types from submodules
-pub use self::input::InputManager;
-// pub use self::input::InputProcessor; // Trait, might be re-exported if used externally
-pub use self::output::StreamCallback;
+pub use self::input::{InputHandler, InputManager};
+pub use self::output::{StreamCallback, Sink, LogSink};
+pub use self::input::source::{Source, timer_source::TimerSource};

--- a/siddhi_rust/src/core/stream/output/mod.rs
+++ b/siddhi_rust/src/core/stream/output/mod.rs
@@ -4,4 +4,4 @@ pub mod stream_callback;
 pub mod sink; // For sink implementations
 
 pub use self::stream_callback::{StreamCallback, LogStreamCallback};
-pub use self::sink::LogSink;
+pub use self::sink::{LogSink, Sink};

--- a/siddhi_rust/src/core/stream/output/sink/log_sink.rs
+++ b/siddhi_rust/src/core/stream/output/sink/log_sink.rs
@@ -1,14 +1,29 @@
 use crate::core::stream::output::stream_callback::StreamCallback;
+use crate::core::stream::output::sink::sink_trait::Sink;
 use crate::core::event::event::Event;
 use std::fmt::Debug;
+use std::sync::{Arc, Mutex};
 
 #[derive(Debug, Clone)]
-pub struct LogSink;
+pub struct LogSink {
+    pub events: Arc<Mutex<Vec<Event>>>,
+}
+
+impl LogSink {
+    pub fn new() -> Self {
+        Self { events: Arc::new(Mutex::new(Vec::new())) }
+    }
+}
 
 impl StreamCallback for LogSink {
     fn receive_events(&self, events: &[Event]) {
         for e in events {
             println!("{:?}", e);
+            self.events.lock().unwrap().push(e.clone());
         }
     }
+}
+
+impl Sink for LogSink {
+    fn clone_box(&self) -> Box<dyn Sink> { Box::new(self.clone()) }
 }

--- a/siddhi_rust/src/core/stream/output/sink/mod.rs
+++ b/siddhi_rust/src/core/stream/output/sink/mod.rs
@@ -1,3 +1,5 @@
 pub mod log_sink;
+pub mod sink_trait;
 
 pub use log_sink::LogSink;
+pub use sink_trait::Sink;

--- a/siddhi_rust/src/core/stream/output/sink/sink_trait.rs
+++ b/siddhi_rust/src/core/stream/output/sink/sink_trait.rs
@@ -1,0 +1,12 @@
+use crate::core::stream::output::stream_callback::StreamCallback;
+use std::fmt::Debug;
+
+pub trait Sink: StreamCallback + Debug + Send + Sync {
+    fn start(&self) {}
+    fn stop(&self) {}
+    fn clone_box(&self) -> Box<dyn Sink>;
+}
+
+impl Clone for Box<dyn Sink> {
+    fn clone(&self) -> Self { self.clone_box() }
+}

--- a/siddhi_rust/tests/source_sink.rs
+++ b/siddhi_rust/tests/source_sink.rs
@@ -1,0 +1,56 @@
+use siddhi_rust::core::stream::{StreamJunction, TimerSource, Source};
+use siddhi_rust::core::stream::input::input_handler::InputHandler;
+use siddhi_rust::core::stream::output::{Sink, LogSink, StreamCallback};
+use siddhi_rust::query_api::definition::stream_definition::StreamDefinition;
+use siddhi_rust::query_api::definition::attribute::Type as AttrType;
+use siddhi_rust::core::config::siddhi_app_context::SiddhiAppContext;
+use siddhi_rust::core::config::siddhi_context::SiddhiContext;
+use siddhi_rust::query_api::siddhi_app::SiddhiApp;
+use siddhi_rust::core::query::output::callback_processor::CallbackProcessor;
+use siddhi_rust::core::config::siddhi_query_context::SiddhiQueryContext;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+#[test]
+fn timer_source_to_log_sink() {
+    let ctx = Arc::new(SiddhiContext::new());
+    let app = Arc::new(SiddhiApp::new("TestApp".to_string()));
+    let app_ctx = Arc::new(SiddhiAppContext::new(Arc::clone(&ctx), "Test".to_string(), Arc::clone(&app), String::new()));
+
+    let stream_def = Arc::new(StreamDefinition::new("FooStream".to_string()).attribute("message".to_string(), AttrType::STRING));
+    let junction = Arc::new(Mutex::new(StreamJunction::new(
+        "FooStream".to_string(),
+        Arc::clone(&stream_def),
+        Arc::clone(&app_ctx),
+        16,
+        false,
+        None,
+    )));
+
+    let publisher = junction.lock().unwrap().construct_publisher();
+    let input_handler = Arc::new(Mutex::new(InputHandler::new(
+        "FooStream".to_string(),
+        0,
+        Arc::new(Mutex::new(publisher)),
+        Arc::clone(&app_ctx),
+    )));
+
+    let sink = LogSink::new();
+    let collected = sink.events.clone();
+    let callback = Arc::new(Mutex::new(Box::new(sink) as Box<dyn StreamCallback>));
+    let cb_processor = Arc::new(Mutex::new(CallbackProcessor::new(
+        callback,
+        Arc::clone(&app_ctx),
+        Arc::new(SiddhiQueryContext::new(Arc::clone(&app_ctx), "cb".to_string(), None)),
+    )));
+    junction.lock().unwrap().subscribe(cb_processor);
+
+    let mut source = TimerSource::new(10);
+    source.start(Arc::clone(&input_handler));
+    std::thread::sleep(Duration::from_millis(50));
+    source.stop();
+    std::thread::sleep(Duration::from_millis(20));
+
+    let events = collected.lock().unwrap();
+    assert!(events.len() > 0);
+}


### PR DESCRIPTION
## Summary
- add `Source` trait and timer source
- add `Sink` trait and enhance `LogSink`
- manage source/sink factories with timer and log implementations
- integration test feeding events from timer source to log sink

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684b99d6eaa08325a46af2a4ae3a7bba