### PR TITLE
Align compare executor rules with Java

### DIFF
--- a/siddhi_rust/src/core/executor/condition/compare_expression_executor.rs
+++ b/siddhi_rust/src/core/executor/condition/compare_expression_executor.rs
@@ -3,8 +3,7 @@
 use crate::core::executor::expression_executor::ExpressionExecutor;
 use crate::core::event::complex_event::ComplexEvent;
 use crate::core::event::value::AttributeValue;
-use crate::query_api::definition::attribute::Type as ApiAttributeType; // Import Type enum
-// Use ConditionCompareOperator from query_api, as it's part of the expression definition
+use crate::query_api::definition::attribute::Type as ApiAttributeType;
 use crate::query_api::expression::condition::CompareOperator as ConditionCompareOperator;
 
 
@@ -13,264 +12,200 @@ pub struct CompareExpressionExecutor {
     left_executor: Box<dyn ExpressionExecutor>,
     right_executor: Box<dyn ExpressionExecutor>,
     operator: ConditionCompareOperator,
-    // Store return types for optimized comparison if known at construction
-    // left_type: Attribute::Type,
-    // right_type: Attribute::Type,
+    cmp_type: ComparisonType,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ComparisonType {
+    Int,
+    Long,
+    Float,
+    Double,
+    Bool,
+    String,
+}
+
+fn as_i32(val: &AttributeValue) -> Option<i32> {
+    match val {
+        AttributeValue::Int(v) => Some(*v),
+        AttributeValue::Long(v) => Some(*v as i32),
+        AttributeValue::Float(v) => Some(*v as i32),
+        AttributeValue::Double(v) => Some(*v as i32),
+        _ => None,
+    }
+}
+
+fn as_i64(val: &AttributeValue) -> Option<i64> {
+    match val {
+        AttributeValue::Int(v) => Some(*v as i64),
+        AttributeValue::Long(v) => Some(*v),
+        AttributeValue::Float(v) => Some(*v as i64),
+        AttributeValue::Double(v) => Some(*v as i64),
+        _ => None,
+    }
+}
+
+fn as_f32(val: &AttributeValue) -> Option<f32> {
+    match val {
+        AttributeValue::Int(v) => Some(*v as f32),
+        AttributeValue::Long(v) => Some(*v as f32),
+        AttributeValue::Float(v) => Some(*v),
+        AttributeValue::Double(v) => Some(*v as f32),
+        _ => None,
+    }
+}
+
+fn as_f64(val: &AttributeValue) -> Option<f64> {
+    match val {
+        AttributeValue::Int(v) => Some(*v as f64),
+        AttributeValue::Long(v) => Some(*v as f64),
+        AttributeValue::Float(v) => Some(*v as f64),
+        AttributeValue::Double(v) => Some(*v),
+        _ => None,
+    }
+}
+
+fn compare_ord<T: Ord>(l: &T, r: &T, op: ConditionCompareOperator) -> bool {
+    match op {
+        ConditionCompareOperator::Equal => l == r,
+        ConditionCompareOperator::NotEqual => l != r,
+        ConditionCompareOperator::GreaterThan => l > r,
+        ConditionCompareOperator::GreaterThanEqual => l >= r,
+        ConditionCompareOperator::LessThan => l < r,
+        ConditionCompareOperator::LessThanEqual => l <= r,
+    }
+}
+
+fn compare_int(l: i32, r: i32, op: ConditionCompareOperator) -> bool {
+    compare_ord(&l, &r, op)
+}
+
+fn compare_i64(l: i64, r: i64, op: ConditionCompareOperator) -> bool {
+    compare_ord(&l, &r, op)
+}
+
+fn compare_f32(l: f32, r: f32, op: ConditionCompareOperator) -> bool {
+    match op {
+        ConditionCompareOperator::Equal => (l - r).abs() < f32::EPSILON,
+        ConditionCompareOperator::NotEqual => (l - r).abs() >= f32::EPSILON,
+        ConditionCompareOperator::GreaterThan => l > r,
+        ConditionCompareOperator::GreaterThanEqual => l >= r,
+        ConditionCompareOperator::LessThan => l < r,
+        ConditionCompareOperator::LessThanEqual => l <= r,
+    }
+}
+
+fn compare_f64(l: f64, r: f64, op: ConditionCompareOperator) -> bool {
+    match op {
+        ConditionCompareOperator::Equal => (l - r).abs() < f64::EPSILON,
+        ConditionCompareOperator::NotEqual => (l - r).abs() >= f64::EPSILON,
+        ConditionCompareOperator::GreaterThan => l > r,
+        ConditionCompareOperator::GreaterThanEqual => l >= r,
+        ConditionCompareOperator::LessThan => l < r,
+        ConditionCompareOperator::LessThanEqual => l <= r,
+    }
+}
+
+fn compare_bool(l: bool, r: bool, op: ConditionCompareOperator) -> bool {
+    let lv = if l { 1 } else { 0 };
+    let rv = if r { 1 } else { 0 };
+    compare_ord(&lv, &rv, op)
 }
 
 impl CompareExpressionExecutor {
-   pub fn new(left: Box<dyn ExpressionExecutor>, right: Box<dyn ExpressionExecutor>, op: ConditionCompareOperator) -> Self {
-       // let left_type = left.get_return_type();
-       // let right_type = right.get_return_type();
-       // TODO: Could perform type compatibility checks here if needed, or select a typed comparison strategy.
-       Self {
-           left_executor: left,
-           right_executor: right,
-           operator: op,
-           // left_type,
-           // right_type,
-       }
-   }
+    pub fn new(
+        left: Box<dyn ExpressionExecutor>,
+        right: Box<dyn ExpressionExecutor>,
+        op: ConditionCompareOperator,
+    ) -> Result<Self, String> {
+        let left_type = left.get_return_type();
+        let right_type = right.get_return_type();
+
+        use ApiAttributeType::*;
+
+        let cmp_type = match (left_type, right_type) {
+            (STRING, STRING) => ComparisonType::String,
+            (BOOL, BOOL) => {
+                if matches!(op, ConditionCompareOperator::Equal | ConditionCompareOperator::NotEqual) {
+                    ComparisonType::Bool
+                } else {
+                    return Err("Only == and != supported for BOOL".to_string());
+                }
+            }
+            (OBJECT, _) | (_, OBJECT) | (STRING, _) | (_, STRING) | (BOOL, _) | (_, BOOL) => {
+                return Err(format!(
+                    "Cannot compare values of types {:?} and {:?}",
+                    left_type, right_type
+                ));
+            }
+            _ => {
+                if left_type == DOUBLE || right_type == DOUBLE {
+                    ComparisonType::Double
+                } else if left_type == FLOAT || right_type == FLOAT {
+                    ComparisonType::Float
+                } else if left_type == LONG || right_type == LONG {
+                    ComparisonType::Long
+                } else {
+                    ComparisonType::Int
+                }
+            }
+        };
+
+        Ok(Self {
+            left_executor: left,
+            right_executor: right,
+            operator: op,
+            cmp_type,
+        })
+    }
 }
 
 impl ExpressionExecutor for CompareExpressionExecutor {
     fn execute(&self, event: Option<&dyn ComplexEvent>) -> Option<AttributeValue> {
-        let left_opt = self.left_executor.execute(event);
-        let right_opt = self.right_executor.execute(event);
+        let left_val = self.left_executor.execute(event)?;
+        let right_val = self.right_executor.execute(event)?;
 
-        match (left_opt, right_opt) {
-            (Some(left), Some(right)) => {
-                // Java CompareConditionExpressionExecutor: return !(left == null || right == null) && execute(left, right);
-                // This means if either is AttributeValue::Null, the comparison is effectively false for the condition.
-                // (Except for IS NULL checks, which are handled by IsNullExpressionExecutor).
-                if matches!(left, AttributeValue::Null) || matches!(right, AttributeValue::Null) {
-                    // For most operators, if one operand is Null, the result is false or Null.
-                    // For IS NULL / IS NOT NULL, it's different.
-                    // Let's assume standard SQL behavior: most comparisons with NULL yield NULL (effectively false in boolean context).
-                    // For strictness, if we want to return AttributeValue::Null for comparisons involving null:
-                    // return Some(AttributeValue::Null);
-                    // For now, returning false as per Java's `!(left == null || right == null)` implies this path leads to overall false.
-                    return Some(AttributeValue::Bool(false));
-                }
-                // TODO: Implement detailed comparison logic for all AttributeValue types and operators.
-                // This is complex: type coercion (e.g. Int vs Long vs Float vs Double), string compares etc.
-                // This requires a robust type promotion and comparison system.
-                // Example simplified comparison (primarily for equality, and only if types are somewhat aligned):
-                // Updated comparison logic
-                let result = match (&left, &right) {
-                    // Integer comparisons
-                    (AttributeValue::Int(l), AttributeValue::Int(r)) => match self.operator {
-                        ConditionCompareOperator::Equal => l == r,
-                        ConditionCompareOperator::NotEqual => l != r,
-                        ConditionCompareOperator::GreaterThan => l > r,
-                        ConditionCompareOperator::GreaterThanEqual => l >= r,
-                        ConditionCompareOperator::LessThan => l < r,
-                        ConditionCompareOperator::LessThanEqual => l <= r,
-                    },
-                    // Long comparisons
-                    (AttributeValue::Long(l), AttributeValue::Long(r)) => match self.operator {
-                        ConditionCompareOperator::Equal => l == r,
-                        ConditionCompareOperator::NotEqual => l != r,
-                        ConditionCompareOperator::GreaterThan => l > r,
-                        ConditionCompareOperator::GreaterThanEqual => l >= r,
-                        ConditionCompareOperator::LessThan => l < r,
-                        ConditionCompareOperator::LessThanEqual => l <= r,
-                    },
-                    // Float comparisons
-                    (AttributeValue::Float(l), AttributeValue::Float(r)) => match self.operator {
-                        ConditionCompareOperator::Equal => (l - r).abs() < f32::EPSILON, // Approx equal for floats
-                        ConditionCompareOperator::NotEqual => (l - r).abs() >= f32::EPSILON,
-                        ConditionCompareOperator::GreaterThan => l > r,
-                        ConditionCompareOperator::GreaterThanEqual => l >= r,
-                        ConditionCompareOperator::LessThan => l < r,
-                        ConditionCompareOperator::LessThanEqual => l <= r,
-                    },
-                    // Double comparisons
-                    (AttributeValue::Double(l), AttributeValue::Double(r)) => match self.operator {
-                        ConditionCompareOperator::Equal => (l - r).abs() < f64::EPSILON, // Approx equal for doubles
-                        ConditionCompareOperator::NotEqual => (l - r).abs() >= f64::EPSILON,
-                        ConditionCompareOperator::GreaterThan => l > r,
-                        ConditionCompareOperator::GreaterThanEqual => l >= r,
-                        ConditionCompareOperator::LessThan => l < r,
-                        ConditionCompareOperator::LessThanEqual => l <= r,
-                    },
-                    // String comparisons with ordering
-                    (AttributeValue::String(l), AttributeValue::String(r)) => {
-                        match self.operator {
-                            ConditionCompareOperator::Equal => l == r,
-                            ConditionCompareOperator::NotEqual => l != r,
-                            ConditionCompareOperator::GreaterThan => l > r,
-                            ConditionCompareOperator::GreaterThanEqual => l >= r,
-                            ConditionCompareOperator::LessThan => l < r,
-                            ConditionCompareOperator::LessThanEqual => l <= r,
-                        }
-                    }
-                    // Bool comparisons (false < true)
-                    (AttributeValue::Bool(l), AttributeValue::Bool(r)) => {
-                        let l_val = if *l { 1 } else { 0 };
-                        let r_val = if *r { 1 } else { 0 };
-                        match self.operator {
-                            ConditionCompareOperator::Equal => l_val == r_val,
-                            ConditionCompareOperator::NotEqual => l_val != r_val,
-                            ConditionCompareOperator::GreaterThan => l_val > r_val,
-                            ConditionCompareOperator::GreaterThanEqual => l_val >= r_val,
-                            ConditionCompareOperator::LessThan => l_val < r_val,
-                            ConditionCompareOperator::LessThanEqual => l_val <= r_val,
-                        }
-                    }
-                    // Mixed numeric comparisons with coercion
-                    (AttributeValue::Int(l), AttributeValue::Long(r)) => {
-                        let l = *l as i64;
-                        let r = *r;
-                        match self.operator {
-                            ConditionCompareOperator::Equal => l == r,
-                            ConditionCompareOperator::NotEqual => l != r,
-                            ConditionCompareOperator::GreaterThan => l > r,
-                            ConditionCompareOperator::GreaterThanEqual => l >= r,
-                            ConditionCompareOperator::LessThan => l < r,
-                            ConditionCompareOperator::LessThanEqual => l <= r,
-                        }
-                    }
-                    (AttributeValue::Long(l), AttributeValue::Int(r)) => {
-                        let l = *l;
-                        let r = *r as i64;
-                        match self.operator {
-                            ConditionCompareOperator::Equal => l == r,
-                            ConditionCompareOperator::NotEqual => l != r,
-                            ConditionCompareOperator::GreaterThan => l > r,
-                            ConditionCompareOperator::GreaterThanEqual => l >= r,
-                            ConditionCompareOperator::LessThan => l < r,
-                            ConditionCompareOperator::LessThanEqual => l <= r,
-                        }
-                    }
-                    (AttributeValue::Int(l), AttributeValue::Float(r)) => {
-                        let l = *l as f32;
-                        let r = *r;
-                        match self.operator {
-                            ConditionCompareOperator::Equal => (l - r).abs() < f32::EPSILON,
-                            ConditionCompareOperator::NotEqual => (l - r).abs() >= f32::EPSILON,
-                            ConditionCompareOperator::GreaterThan => l > r,
-                            ConditionCompareOperator::GreaterThanEqual => l >= r,
-                            ConditionCompareOperator::LessThan => l < r,
-                            ConditionCompareOperator::LessThanEqual => l <= r,
-                        }
-                    }
-                    (AttributeValue::Float(l), AttributeValue::Int(r)) => {
-                        let l = *l;
-                        let r = *r as f32;
-                        match self.operator {
-                            ConditionCompareOperator::Equal => (l - r).abs() < f32::EPSILON,
-                            ConditionCompareOperator::NotEqual => (l - r).abs() >= f32::EPSILON,
-                            ConditionCompareOperator::GreaterThan => l > r,
-                            ConditionCompareOperator::GreaterThanEqual => l >= r,
-                            ConditionCompareOperator::LessThan => l < r,
-                            ConditionCompareOperator::LessThanEqual => l <= r,
-                        }
-                    }
-                    (AttributeValue::Int(l), AttributeValue::Double(r)) => {
-                        let l = *l as f64;
-                        let r = *r;
-                        match self.operator {
-                            ConditionCompareOperator::Equal => (l - r).abs() < f64::EPSILON,
-                            ConditionCompareOperator::NotEqual => (l - r).abs() >= f64::EPSILON,
-                            ConditionCompareOperator::GreaterThan => l > r,
-                            ConditionCompareOperator::GreaterThanEqual => l >= r,
-                            ConditionCompareOperator::LessThan => l < r,
-                            ConditionCompareOperator::LessThanEqual => l <= r,
-                        }
-                    }
-                    (AttributeValue::Double(l), AttributeValue::Int(r)) => {
-                        let l = *l;
-                        let r = *r as f64;
-                        match self.operator {
-                            ConditionCompareOperator::Equal => (l - r).abs() < f64::EPSILON,
-                            ConditionCompareOperator::NotEqual => (l - r).abs() >= f64::EPSILON,
-                            ConditionCompareOperator::GreaterThan => l > r,
-                            ConditionCompareOperator::GreaterThanEqual => l >= r,
-                            ConditionCompareOperator::LessThan => l < r,
-                            ConditionCompareOperator::LessThanEqual => l <= r,
-                        }
-                    }
-                    (AttributeValue::Long(l), AttributeValue::Float(r)) => {
-                        let l = *l as f32;
-                        let r = *r;
-                        match self.operator {
-                            ConditionCompareOperator::Equal => (l - r).abs() < f32::EPSILON,
-                            ConditionCompareOperator::NotEqual => (l - r).abs() >= f32::EPSILON,
-                            ConditionCompareOperator::GreaterThan => l > r,
-                            ConditionCompareOperator::GreaterThanEqual => l >= r,
-                            ConditionCompareOperator::LessThan => l < r,
-                            ConditionCompareOperator::LessThanEqual => l <= r,
-                        }
-                    }
-                    (AttributeValue::Float(l), AttributeValue::Long(r)) => {
-                        let l = *l;
-                        let r = *r as f32;
-                        match self.operator {
-                            ConditionCompareOperator::Equal => (l - r).abs() < f32::EPSILON,
-                            ConditionCompareOperator::NotEqual => (l - r).abs() >= f32::EPSILON,
-                            ConditionCompareOperator::GreaterThan => l > r,
-                            ConditionCompareOperator::GreaterThanEqual => l >= r,
-                            ConditionCompareOperator::LessThan => l < r,
-                            ConditionCompareOperator::LessThanEqual => l <= r,
-                        }
-                    }
-                    (AttributeValue::Long(l), AttributeValue::Double(r)) => {
-                        let l = *l as f64;
-                        let r = *r;
-                        match self.operator {
-                            ConditionCompareOperator::Equal => (l - r).abs() < f64::EPSILON,
-                            ConditionCompareOperator::NotEqual => (l - r).abs() >= f64::EPSILON,
-                            ConditionCompareOperator::GreaterThan => l > r,
-                            ConditionCompareOperator::GreaterThanEqual => l >= r,
-                            ConditionCompareOperator::LessThan => l < r,
-                            ConditionCompareOperator::LessThanEqual => l <= r,
-                        }
-                    }
-                    (AttributeValue::Double(l), AttributeValue::Long(r)) => {
-                        let l = *l;
-                        let r = *r as f64;
-                        match self.operator {
-                            ConditionCompareOperator::Equal => (l - r).abs() < f64::EPSILON,
-                            ConditionCompareOperator::NotEqual => (l - r).abs() >= f64::EPSILON,
-                            ConditionCompareOperator::GreaterThan => l > r,
-                            ConditionCompareOperator::GreaterThanEqual => l >= r,
-                            ConditionCompareOperator::LessThan => l < r,
-                            ConditionCompareOperator::LessThanEqual => l <= r,
-                        }
-                    }
-                    (AttributeValue::Float(l), AttributeValue::Double(r)) => {
-                        let l = *l as f64;
-                        let r = *r;
-                        match self.operator {
-                            ConditionCompareOperator::Equal => (l - r).abs() < f64::EPSILON,
-                            ConditionCompareOperator::NotEqual => (l - r).abs() >= f64::EPSILON,
-                            ConditionCompareOperator::GreaterThan => l > r,
-                            ConditionCompareOperator::GreaterThanEqual => l >= r,
-                            ConditionCompareOperator::LessThan => l < r,
-                            ConditionCompareOperator::LessThanEqual => l <= r,
-                        }
-                    }
-                    (AttributeValue::Double(l), AttributeValue::Float(r)) => {
-                        let l = *l;
-                        let r = *r as f64;
-                        match self.operator {
-                            ConditionCompareOperator::Equal => (l - r).abs() < f64::EPSILON,
-                            ConditionCompareOperator::NotEqual => (l - r).abs() >= f64::EPSILON,
-                            ConditionCompareOperator::GreaterThan => l > r,
-                            ConditionCompareOperator::GreaterThanEqual => l >= r,
-                            ConditionCompareOperator::LessThan => l < r,
-                            ConditionCompareOperator::LessThanEqual => l <= r,
-                        }
-                    }
-                    _ => {
-                        return Some(AttributeValue::Bool(false));
-                    }
-                };
-                Some(AttributeValue::Bool(result))
-            }
-            _ => None, // If any side fails to execute, propagate None (or error)
+        if matches!(left_val, AttributeValue::Null) || matches!(right_val, AttributeValue::Null) {
+            return match self.operator {
+                ConditionCompareOperator::NotEqual => Some(AttributeValue::Bool(true)),
+                _ => Some(AttributeValue::Bool(false)),
+            };
         }
+
+        let res = match self.cmp_type {
+            ComparisonType::Int => {
+                let l = as_i32(&left_val)?;
+                let r = as_i32(&right_val)?;
+                compare_int(l, r, self.operator)
+            }
+            ComparisonType::Long => {
+                let l = as_i64(&left_val)?;
+                let r = as_i64(&right_val)?;
+                compare_i64(l, r, self.operator)
+            }
+            ComparisonType::Float => {
+                let l = as_f32(&left_val)?;
+                let r = as_f32(&right_val)?;
+                compare_f32(l, r, self.operator)
+            }
+            ComparisonType::Double => {
+                let l = as_f64(&left_val)?;
+                let r = as_f64(&right_val)?;
+                compare_f64(l, r, self.operator)
+            }
+            ComparisonType::String => {
+                let l = match &left_val { AttributeValue::String(s) => s, _ => return None };
+                let r = match &right_val { AttributeValue::String(s) => s, _ => return None };
+                compare_ord(l, r, self.operator)
+            }
+            ComparisonType::Bool => {
+                let l = match &left_val { AttributeValue::Bool(b) => *b, _ => return None };
+                let r = match &right_val { AttributeValue::Bool(b) => *b, _ => return None };
+                compare_bool(l, r, self.operator)
+            }
+        };
+
+        Some(AttributeValue::Bool(res))
     }
 
     fn get_return_type(&self) -> ApiAttributeType {
@@ -282,6 +217,7 @@ impl ExpressionExecutor for CompareExpressionExecutor {
             left_executor: self.left_executor.clone_executor(siddhi_app_context),
             right_executor: self.right_executor.clone_executor(siddhi_app_context),
             operator: self.operator,
+            cmp_type: self.cmp_type,
         })
     }
 }
@@ -301,7 +237,7 @@ mod tests {
     fn test_compare_greater_than_int_true() { // Renamed as per subtask suggestion (though original would be fine too)
         let left_exec = Box::new(ConstantExpressionExecutor::new(AttributeValue::Int(20), ApiAttributeType::INT));
         let right_exec = Box::new(ConstantExpressionExecutor::new(AttributeValue::Int(10), ApiAttributeType::INT));
-        let cmp_exec = CompareExpressionExecutor::new(left_exec, right_exec, ApiCompareOperator::GreaterThan);
+        let cmp_exec = CompareExpressionExecutor::new(left_exec, right_exec, ApiCompareOperator::GreaterThan).unwrap();
 
         let result = cmp_exec.execute(None);
         assert_eq!(result, Some(AttributeValue::Bool(true)));
@@ -312,7 +248,7 @@ mod tests {
     fn test_compare_less_than_int_false() {
         let left_exec = Box::new(ConstantExpressionExecutor::new(AttributeValue::Int(20), ApiAttributeType::INT));
         let right_exec = Box::new(ConstantExpressionExecutor::new(AttributeValue::Int(10), ApiAttributeType::INT));
-        let cmp_exec = CompareExpressionExecutor::new(left_exec, right_exec, ApiCompareOperator::LessThan);
+        let cmp_exec = CompareExpressionExecutor::new(left_exec, right_exec, ApiCompareOperator::LessThan).unwrap();
 
         let result = cmp_exec.execute(None);
         assert_eq!(result, Some(AttributeValue::Bool(false)));
@@ -322,7 +258,7 @@ mod tests {
     fn test_compare_equal_float_true() {
         let left_exec = Box::new(ConstantExpressionExecutor::new(AttributeValue::Float(10.5), ApiAttributeType::FLOAT));
         let right_exec = Box::new(ConstantExpressionExecutor::new(AttributeValue::Float(10.5), ApiAttributeType::FLOAT));
-        let cmp_exec = CompareExpressionExecutor::new(left_exec, right_exec, ApiCompareOperator::Equal);
+        let cmp_exec = CompareExpressionExecutor::new(left_exec, right_exec, ApiCompareOperator::Equal).unwrap();
 
         let result = cmp_exec.execute(None);
         assert_eq!(result, Some(AttributeValue::Bool(true)));
@@ -332,7 +268,7 @@ mod tests {
     fn test_compare_not_equal_string_true() {
         let left_exec = Box::new(ConstantExpressionExecutor::new(AttributeValue::String("hello".to_string()), ApiAttributeType::STRING));
         let right_exec = Box::new(ConstantExpressionExecutor::new(AttributeValue::String("world".to_string()), ApiAttributeType::STRING));
-        let cmp_exec = CompareExpressionExecutor::new(left_exec, right_exec, ApiCompareOperator::NotEqual);
+        let cmp_exec = CompareExpressionExecutor::new(left_exec, right_exec, ApiCompareOperator::NotEqual).unwrap();
 
         let result = cmp_exec.execute(None);
         assert_eq!(result, Some(AttributeValue::Bool(true)));
@@ -342,7 +278,7 @@ mod tests {
     fn test_compare_with_null_operand() {
         let left_exec = Box::new(ConstantExpressionExecutor::new(AttributeValue::Int(20), ApiAttributeType::INT));
         let right_exec = Box::new(ConstantExpressionExecutor::new(AttributeValue::Null, ApiAttributeType::INT)); // Null operand
-        let cmp_exec = CompareExpressionExecutor::new(left_exec, right_exec, ApiCompareOperator::GreaterThan);
+        let cmp_exec = CompareExpressionExecutor::new(left_exec, right_exec, ApiCompareOperator::GreaterThan).unwrap();
 
         // Current logic: if either operand is Null, returns Bool(false)
         let result = cmp_exec.execute(None);
@@ -353,18 +289,15 @@ mod tests {
     fn test_compare_incompatible_types() {
         let left_exec = Box::new(ConstantExpressionExecutor::new(AttributeValue::Int(20), ApiAttributeType::INT));
         let right_exec = Box::new(ConstantExpressionExecutor::new(AttributeValue::String("text".to_string()), ApiAttributeType::STRING));
-        let cmp_exec = CompareExpressionExecutor::new(left_exec, right_exec, ApiCompareOperator::GreaterThan);
-
-        // Current logic: if types are incompatible for the operation, returns Bool(false)
-        let result = cmp_exec.execute(None);
-        assert_eq!(result, Some(AttributeValue::Bool(false)));
+        let res = CompareExpressionExecutor::new(left_exec, right_exec, ApiCompareOperator::GreaterThan);
+        assert!(res.is_err());
     }
 
     #[test]
     fn test_compare_clone() {
         let left_exec = Box::new(ConstantExpressionExecutor::new(AttributeValue::Long(100), ApiAttributeType::LONG));
         let right_exec = Box::new(ConstantExpressionExecutor::new(AttributeValue::Long(50), ApiAttributeType::LONG));
-        let cmp_exec = CompareExpressionExecutor::new(left_exec, right_exec, ApiCompareOperator::GreaterThanEqual);
+        let cmp_exec = CompareExpressionExecutor::new(left_exec, right_exec, ApiCompareOperator::GreaterThanEqual).unwrap();
 
         let app_ctx_placeholder = Arc::new(SiddhiAppContext::default_for_testing());
         let cloned_exec = cmp_exec.clone_executor(&app_ctx_placeholder);
@@ -378,7 +311,7 @@ mod tests {
     fn test_operator_equal_int() {
         let left = Box::new(ConstantExpressionExecutor::new(AttributeValue::Int(5), ApiAttributeType::INT));
         let right = Box::new(ConstantExpressionExecutor::new(AttributeValue::Int(5), ApiAttributeType::INT));
-        let cmp = CompareExpressionExecutor::new(left, right, ApiCompareOperator::Equal);
+        let cmp = CompareExpressionExecutor::new(left, right, ApiCompareOperator::Equal).unwrap();
         assert_eq!(cmp.execute(None), Some(AttributeValue::Bool(true)));
     }
 
@@ -386,7 +319,7 @@ mod tests {
     fn test_operator_not_equal_long() {
         let left = Box::new(ConstantExpressionExecutor::new(AttributeValue::Long(5), ApiAttributeType::LONG));
         let right = Box::new(ConstantExpressionExecutor::new(AttributeValue::Long(10), ApiAttributeType::LONG));
-        let cmp = CompareExpressionExecutor::new(left, right, ApiCompareOperator::NotEqual);
+        let cmp = CompareExpressionExecutor::new(left, right, ApiCompareOperator::NotEqual).unwrap();
         assert_eq!(cmp.execute(None), Some(AttributeValue::Bool(true)));
     }
 
@@ -394,7 +327,7 @@ mod tests {
     fn test_operator_greater_than_cross() {
         let left = Box::new(ConstantExpressionExecutor::new(AttributeValue::Float(7.5), ApiAttributeType::FLOAT));
         let right = Box::new(ConstantExpressionExecutor::new(AttributeValue::Int(7), ApiAttributeType::INT));
-        let cmp = CompareExpressionExecutor::new(left, right, ApiCompareOperator::GreaterThan);
+        let cmp = CompareExpressionExecutor::new(left, right, ApiCompareOperator::GreaterThan).unwrap();
         assert_eq!(cmp.execute(None), Some(AttributeValue::Bool(true)));
     }
 
@@ -402,7 +335,7 @@ mod tests {
     fn test_operator_greater_than_equal_cross() {
         let left = Box::new(ConstantExpressionExecutor::new(AttributeValue::Double(7.0), ApiAttributeType::DOUBLE));
         let right = Box::new(ConstantExpressionExecutor::new(AttributeValue::Long(7), ApiAttributeType::LONG));
-        let cmp = CompareExpressionExecutor::new(left, right, ApiCompareOperator::GreaterThanEqual);
+        let cmp = CompareExpressionExecutor::new(left, right, ApiCompareOperator::GreaterThanEqual).unwrap();
         assert_eq!(cmp.execute(None), Some(AttributeValue::Bool(true)));
     }
 
@@ -410,7 +343,7 @@ mod tests {
     fn test_operator_less_than_string() {
         let left = Box::new(ConstantExpressionExecutor::new(AttributeValue::String("apple".to_string()), ApiAttributeType::STRING));
         let right = Box::new(ConstantExpressionExecutor::new(AttributeValue::String("banana".to_string()), ApiAttributeType::STRING));
-        let cmp = CompareExpressionExecutor::new(left, right, ApiCompareOperator::LessThan);
+        let cmp = CompareExpressionExecutor::new(left, right, ApiCompareOperator::LessThan).unwrap();
         assert_eq!(cmp.execute(None), Some(AttributeValue::Bool(true)));
     }
 
@@ -418,7 +351,6 @@ mod tests {
     fn test_operator_less_than_equal_bool() {
         let left = Box::new(ConstantExpressionExecutor::new(AttributeValue::Bool(false), ApiAttributeType::BOOL));
         let right = Box::new(ConstantExpressionExecutor::new(AttributeValue::Bool(true), ApiAttributeType::BOOL));
-        let cmp = CompareExpressionExecutor::new(left, right, ApiCompareOperator::LessThanEqual);
-        assert_eq!(cmp.execute(None), Some(AttributeValue::Bool(true)));
+        assert!(CompareExpressionExecutor::new(left, right, ApiCompareOperator::LessThanEqual).is_err());
     }
 }

--- a/siddhi_rust/src/core/util/parser/expression_parser.rs
+++ b/siddhi_rust/src/core/util/parser/expression_parser.rs
@@ -284,7 +284,10 @@ pub fn parse_expression<'a>( // Added lifetime 'a
                 .query_context_start_index
                 .map(|(l, c)| format!("line {}, column {}", l, c))
                 .unwrap_or_else(|| "unknown location".to_string());
-            Ok(Box::new(CompareExpressionExecutor::new(left_exec, right_exec, api_op.operator.clone())))
+            Ok(Box::new(
+                CompareExpressionExecutor::new(left_exec, right_exec, api_op.operator.clone())
+                    .map_err(|e| format!("{} at {} in query '{}'", e, loc, context.query_name))?
+            ))
         }
         ApiExpression::IsNull(api_op) => {
             if let Some(inner_expr) = &api_op.expression {

--- a/siddhi_rust/tests/compare_expression.rs
+++ b/siddhi_rust/tests/compare_expression.rs
@@ -22,7 +22,7 @@ fn dummy_ctx() -> Arc<SiddhiAppContext> {
 fn test_numeric_comparison() {
     let left = Box::new(ConstantExpressionExecutor::new(AttributeValue::Int(5), AttrType::INT));
     let right = Box::new(ConstantExpressionExecutor::new(AttributeValue::Int(3), AttrType::INT));
-    let cmp = CompareExpressionExecutor::new(left, right, CompareOp::GreaterThan);
+    let cmp = CompareExpressionExecutor::new(left, right, CompareOp::GreaterThan).unwrap();
     assert_eq!(cmp.execute(None), Some(AttributeValue::Bool(true)));
 }
 
@@ -30,7 +30,7 @@ fn test_numeric_comparison() {
 fn test_string_equality() {
     let left = Box::new(ConstantExpressionExecutor::new(AttributeValue::String("a".to_string()), AttrType::STRING));
     let right = Box::new(ConstantExpressionExecutor::new(AttributeValue::String("a".to_string()), AttrType::STRING));
-    let cmp = CompareExpressionExecutor::new(left, right, CompareOp::Equal);
+    let cmp = CompareExpressionExecutor::new(left, right, CompareOp::Equal).unwrap();
     assert_eq!(cmp.execute(None), Some(AttributeValue::Bool(true)));
 }
 
@@ -38,7 +38,7 @@ fn test_string_equality() {
 fn test_cross_type_compare() {
     let left = Box::new(ConstantExpressionExecutor::new(AttributeValue::Int(5), AttrType::INT));
     let right = Box::new(ConstantExpressionExecutor::new(AttributeValue::Double(4.5), AttrType::DOUBLE));
-    let cmp = CompareExpressionExecutor::new(left, right, CompareOp::GreaterThan);
+    let cmp = CompareExpressionExecutor::new(left, right, CompareOp::GreaterThan).unwrap();
     assert_eq!(cmp.execute(None), Some(AttributeValue::Bool(true)));
 }
 
@@ -47,7 +47,21 @@ fn test_clone_executor() {
     let ctx = dummy_ctx();
     let left = Box::new(ConstantExpressionExecutor::new(AttributeValue::String("b".to_string()), AttrType::STRING));
     let right = Box::new(ConstantExpressionExecutor::new(AttributeValue::String("a".to_string()), AttrType::STRING));
-    let cmp = CompareExpressionExecutor::new(left, right, CompareOp::GreaterThan);
+    let cmp = CompareExpressionExecutor::new(left, right, CompareOp::GreaterThan).unwrap();
     let cloned = cmp.clone_executor(&ctx);
     assert_eq!(cloned.execute(None), Some(AttributeValue::Bool(true)));
+}
+
+#[test]
+fn test_invalid_type_error() {
+    let left = Box::new(ConstantExpressionExecutor::new(AttributeValue::String("a".to_string()), AttrType::STRING));
+    let right = Box::new(ConstantExpressionExecutor::new(AttributeValue::Int(1), AttrType::INT));
+    assert!(CompareExpressionExecutor::new(left, right, CompareOp::Equal).is_err());
+}
+
+#[test]
+fn test_bool_operator_error() {
+    let left = Box::new(ConstantExpressionExecutor::new(AttributeValue::Bool(true), AttrType::BOOL));
+    let right = Box::new(ConstantExpressionExecutor::new(AttributeValue::Bool(false), AttrType::BOOL));
+    assert!(CompareExpressionExecutor::new(left, right, CompareOp::LessThan).is_err());
 }


### PR DESCRIPTION
## Summary
- implement type checks and coercion in `CompareExpressionExecutor`
- propagate compare construction errors from `ExpressionParser`
- adjust unit tests for new behaviour and add failure cases

## Testing
- `cargo test --test compare_expression -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_684b9dd8cf1883258b0a0d0fb05db6b3