### PR TITLE
Implement store query parsing

### DIFF
--- a/siddhi_rust/src/query_api/execution/query/on_demand_query.rs
+++ b/siddhi_rust/src/query_api/execution/query/on_demand_query.rs
@@ -4,6 +4,11 @@ use crate::query_api::siddhi_element::SiddhiElement;
 use crate::query_api::execution::query::selection::Selector;
 use super::{OutputStream, OutputEventType}; // Use parent module's re-exports
 use crate::query_api::execution::query::input::InputStore;
+use crate::query_api::expression::Expression;
+use crate::query_api::execution::query::output::output_stream::{
+    OutputStreamAction, DeleteStreamAction, UpdateStreamAction, UpdateOrInsertStreamAction,
+};
+use crate::query_api::execution::query::output::stream::UpdateSet;
 
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Copy)] // Added Eq, Hash, Copy
@@ -69,6 +74,46 @@ impl OnDemandQuery {
     pub fn set_type(mut self, query_type: OnDemandQueryType) -> Self {
         self.on_demand_query_type = Some(query_type);
         self
+    }
+
+    pub fn delete_by(mut self, output_table_id: String, on_deleting_expression: Expression) -> Self {
+        let action = DeleteStreamAction { target_id: output_table_id, on_delete_expression: on_deleting_expression };
+        self.output_stream = OutputStream::new(OutputStreamAction::Delete(action), Some(OutputEventType::CurrentEvents));
+        self
+    }
+
+    pub fn update_by(mut self, output_table_id: String, on_update_expression: Expression) -> Self {
+        let action = UpdateStreamAction { target_id: output_table_id, on_update_expression, update_set_clause: None };
+        self.output_stream = OutputStream::new(OutputStreamAction::Update(action), Some(OutputEventType::CurrentEvents));
+        self
+    }
+
+    pub fn update_by_with_set(mut self, output_table_id: String, update_set_attributes: UpdateSet, on_update_expression: Expression) -> Self {
+        let action = UpdateStreamAction { target_id: output_table_id, on_update_expression, update_set_clause: Some(update_set_attributes) };
+        self.output_stream = OutputStream::new(OutputStreamAction::Update(action), Some(OutputEventType::CurrentEvents));
+        self
+    }
+
+    pub fn update_or_insert_by(mut self, output_table_id: String, update_set_attributes: UpdateSet, on_update_expression: Expression) -> Self {
+        let action = UpdateOrInsertStreamAction { target_id: output_table_id, on_update_expression, update_set_clause: Some(update_set_attributes) };
+        self.output_stream = OutputStream::new(OutputStreamAction::UpdateOrInsert(action), Some(OutputEventType::CurrentEvents));
+        self
+    }
+
+    pub fn get_input_store(&self) -> Option<&InputStore> {
+        self.input_store.as_ref()
+    }
+
+    pub fn get_selector(&self) -> &Selector {
+        &self.selector
+    }
+
+    pub fn get_output_stream(&self) -> &OutputStream {
+        &self.output_stream
+    }
+
+    pub fn get_type(&self) -> Option<OnDemandQueryType> {
+        self.on_demand_query_type
     }
 }
 

--- a/siddhi_rust/src/query_api/execution/query/store_query.rs
+++ b/siddhi_rust/src/query_api/execution/query/store_query.rs
@@ -1,5 +1,8 @@
 use crate::query_api::siddhi_element::SiddhiElement;
 use super::on_demand_query::{OnDemandQuery, OnDemandQueryType}; // Import Rust OnDemandQuery
+use crate::query_api::execution::query::input::InputStore;
+use crate::query_api::execution::query::selection::Selector;
+use super::{OutputStream};
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Copy)] // Added Eq, Hash, Copy
 pub enum StoreQueryType {
@@ -69,6 +72,37 @@ impl StoreQuery {
         self.on_demand_query = self.on_demand_query.set_type(odq_type);
         self.on_demand_query.siddhi_element = current_siddhi_element; // Ensure inner query shares context
         self
+    }
+
+    pub fn from(mut self, input_store: InputStore) -> Self {
+        self.on_demand_query = self.on_demand_query.from(input_store);
+        self
+    }
+
+    pub fn select(mut self, selector: Selector) -> Self {
+        self.on_demand_query = self.on_demand_query.select(selector);
+        self
+    }
+
+    pub fn out_stream(mut self, output_stream: OutputStream) -> Self {
+        self.on_demand_query = self.on_demand_query.out_stream(output_stream);
+        self
+    }
+
+    pub fn get_input_store(&self) -> Option<&InputStore> {
+        self.on_demand_query.get_input_store()
+    }
+
+    pub fn get_selector(&self) -> &Selector {
+        self.on_demand_query.get_selector()
+    }
+
+    pub fn get_output_stream(&self) -> &OutputStream {
+        self.on_demand_query.get_output_stream()
+    }
+
+    pub fn get_on_demand_query(&self) -> &OnDemandQuery {
+        &self.on_demand_query
     }
 }
 

--- a/siddhi_rust/src/query_compiler/grammar.lalrpop
+++ b/siddhi_rust/src/query_compiler/grammar.lalrpop
@@ -7,7 +7,7 @@ use crate::query_api::definition::{StreamDefinition, TableDefinition, Aggregatio
 use crate::query_api::definition::attribute::Type as AttributeType;
 use crate::query_api::definition::attribute::Attribute;
 use crate::query_api::execution::query::input::handler::WindowHandler;
-use crate::query_api::execution::query::{Query};
+use crate::query_api::execution::query::{Query, OnDemandQuery, StoreQuery, OnDemandQueryType};
 use crate::query_api::execution::query::selection::Selector;
 use crate::query_api::execution::query::output::output_stream::{
     OutputStream,
@@ -19,6 +19,8 @@ use crate::query_api::execution::query::output::output_stream::{
 use crate::query_api::execution::query::input::{
     InputStream, SingleInputStream, JoinType, StateInputStreamType, StateElement, State,
 };
+use crate::query_api::execution::query::input::store::{InputStore, Store, ConditionInputStore, AggregationInputStore};
+use crate::query_api::aggregation::Within;
 use crate::query_api::expression::{Expression, variable::Variable};
 use crate::query_api::expression::condition::compare::Operator as CompareOperator;
 use crate::query_api::aggregation::TimePeriod;
@@ -28,8 +30,29 @@ use crate::query_api::annotation::Annotation;
 pub AnnotationStmt: Annotation = {
     "@" <name:Ident> ":" <key:Ident> "(" <val:STRING> ")" => {
         Annotation::new(name).element(Some(key), val)
+    } 
+};
+
+pub OnDemandQueryStmt: OnDemandQuery = {
+    "from" <st:InputStoreRule> "select" <sel:SelectList> => {
+        let mut selector = Selector::new();
+        for (expr, alias) in sel {
+            match alias {
+                Some(a) => selector = selector.select(a, expr),
+                None => match expr.clone() {
+                    Expression::Variable(var) => selector = selector.select_variable(var),
+                    _ => selector = selector.select(String::new(), expr),
+                },
+            }
+        }
+        OnDemandQuery::query()
+            .from(st)
+            .select(selector)
+            .set_type(OnDemandQueryType::Find)
     }
 };
+
+pub StoreQueryStmt: StoreQuery = { <q:OnDemandQueryStmt> => StoreQuery::new(q) };
 
 Annotations: Vec<Annotation> = {
     <first:AnnotationStmt> <rest:AnnotationStmt*> => {
@@ -173,6 +196,19 @@ InputStreamRule: InputStream = {
         for (_, u) in rest { st = State::next(st, u); }
         InputStream::sequence_stream(st, None)
     },
+};
+
+InputStoreRule: InputStore = {
+    <id:Ident> "on" <cond:Expression> "within" <within_expr:Expression> "per" <per_expr:Expression> => {
+        let store = Store::new_with_id(id);
+        let within = Within::new_with_pattern(within_expr);
+        InputStore::Aggregation(Box::new(AggregationInputStore::new_with_condition(store, cond, within, per_expr)))
+    },
+    <id:Ident> "on" <cond:Expression> => {
+        let store = Store::new_with_id(id);
+        InputStore::Condition(Box::new(ConditionInputStore::new(store, cond)))
+    },
+    <id:Ident> => InputStore::Store(Store::new_with_id(id)),
 };
 
 Unit: StateElement = {

--- a/siddhi_rust/src/query_compiler/siddhi_compiler.rs
+++ b/siddhi_rust/src/query_compiler/siddhi_compiler.rs
@@ -171,21 +171,18 @@ pub fn parse_time_constant(time_const_string: &str) -> Result<ExpressionConstant
 }
 
 pub fn parse_on_demand_query(query_string: &str) -> Result<OnDemandQuery, String> {
-    let _ = update_variables(query_string)?;
-    Err("OnDemandQuery parsing not implemented".to_string())
+    let s = update_variables(query_string)?;
+    grammar::OnDemandQueryStmtParser::new()
+        .parse(&s)
+        .map_err(|e| format!("{:?}", e))
 }
 
 // parseStoreQuery in Java calls parseOnDemandQuery.
 pub fn parse_store_query(store_query_string: &str) -> Result<StoreQuery, String> {
-    match parse_on_demand_query(store_query_string) {
-        Ok(on_demand_query) => {
-            // If OnDemandQuery parsing itself is deferred, this will also be deferred.
-            // Assuming StoreQuery::new exists and takes OnDemandQuery.
-            Ok(StoreQuery::new(on_demand_query))
-        }
-        Err(e) => Err(e), // Propagate error from parse_on_demand_query
-    }
-    // Additional variants of StoreQuery parsing are not implemented.
+    let s = update_variables(store_query_string)?;
+    grammar::StoreQueryStmtParser::new()
+        .parse(&s)
+        .map_err(|e| format!("{:?}", e))
 }
 
 pub fn parse_expression(expr_string: &str) -> Result<Expression, String> {

--- a/siddhi_rust/tests/parse_store_on_demand.rs
+++ b/siddhi_rust/tests/parse_store_on_demand.rs
@@ -1,0 +1,26 @@
+use siddhi_rust::query_compiler::{parse_on_demand_query, parse_store_query};
+use siddhi_rust::query_api::execution::query::{OnDemandQuery, OnDemandQueryType, StoreQuery};
+use siddhi_rust::query_api::execution::query::input::store::InputStore;
+use siddhi_rust::query_api::execution::query::selection::Selector;
+use siddhi_rust::query_api::expression::variable::Variable;
+
+#[test]
+fn test_parse_on_demand_query_basic() {
+    let parsed = parse_on_demand_query("from StockTable select symbol").unwrap();
+    let expected = OnDemandQuery::query()
+        .from(InputStore::Store(InputStore::store("StockTable".to_string())))
+        .select(Selector::new().select_variable(Variable::new("symbol".to_string())))
+        .set_type(OnDemandQueryType::Find);
+    assert_eq!(parsed, expected);
+}
+
+#[test]
+fn test_parse_store_query_basic() {
+    let parsed = parse_store_query("from StockTable select symbol").unwrap();
+    let expected_odq = OnDemandQuery::query()
+        .from(InputStore::Store(InputStore::store("StockTable".to_string())))
+        .select(Selector::new().select_variable(Variable::new("symbol".to_string())))
+        .set_type(OnDemandQueryType::Find);
+    let expected = StoreQuery::new(expected_odq);
+    assert_eq!(parsed, expected);
+}


### PR DESCRIPTION
## Summary
- add builder methods for `OnDemandQuery` and `StoreQuery`
- extend Siddhi grammar with `InputStoreRule`, `OnDemandQueryStmt`, and `StoreQueryStmt`
- implement `parse_on_demand_query` and `parse_store_query`
- test the new parse functions

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684ba43112a0832591eea85318e2e8cd