### PR TITLE
Rust Siddhi built-in function factories

### DIFF
--- a/siddhi_rust/src/core/config/siddhi_context.rs
+++ b/siddhi_rust/src/core/config/siddhi_context.rs
@@ -295,6 +295,7 @@ impl SiddhiContext {
         };
         use crate::core::table::InMemoryTableFactory;
         use crate::core::extension::{LogSinkFactory, TimerSourceFactory};
+        use crate::core::executor::function::builtin_wrapper::register_builtin_scalar_functions;
 
         self.add_window_factory("length".to_string(), Box::new(LengthWindowFactory));
         self.add_window_factory("time".to_string(), Box::new(TimeWindowFactory));
@@ -311,6 +312,8 @@ impl SiddhiContext {
         self.add_table_factory("inMemory".to_string(), Box::new(InMemoryTableFactory));
         self.add_source_factory("timer".to_string(), Box::new(TimerSourceFactory));
         self.add_sink_factory("log".to_string(), Box::new(LogSinkFactory));
+
+        register_builtin_scalar_functions(self);
     }
 
     // --- Extension Factory Methods ---

--- a/siddhi_rust/src/core/executor/function/builtin_wrapper.rs
+++ b/siddhi_rust/src/core/executor/function/builtin_wrapper.rs
@@ -1,0 +1,174 @@
+use crate::core::executor::expression_executor::ExpressionExecutor;
+use crate::core::event::complex_event::ComplexEvent;
+use crate::core::event::value::AttributeValue;
+use crate::query_api::definition::attribute::Type as ApiAttributeType;
+use crate::core::config::siddhi_app_context::SiddhiAppContext;
+use crate::core::executor::function::*;
+use std::sync::Arc;
+
+pub type BuiltinBuilder = fn(Vec<Box<dyn ExpressionExecutor>>) -> Result<Box<dyn ExpressionExecutor>, String>;
+
+pub struct BuiltinScalarFunction {
+    pub name: &'static str,
+    pub builder: BuiltinBuilder,
+    executor: Option<Box<dyn ExpressionExecutor>>,
+}
+
+impl Clone for BuiltinScalarFunction {
+    fn clone(&self) -> Self {
+        Self::new(self.name, self.builder)
+    }
+}
+
+impl std::fmt::Debug for BuiltinScalarFunction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BuiltinScalarFunction")
+            .field("name", &self.name)
+            .finish()
+    }
+}
+
+impl BuiltinScalarFunction {
+    pub fn new(name: &'static str, builder: BuiltinBuilder) -> Self {
+        Self { name, builder, executor: None }
+    }
+}
+
+impl ExpressionExecutor for BuiltinScalarFunction {
+    fn execute(&self, event: Option<&dyn ComplexEvent>) -> Option<AttributeValue> {
+        self.executor.as_ref()?.execute(event)
+    }
+
+    fn get_return_type(&self) -> ApiAttributeType {
+        self.executor.as_ref().map(|e| e.get_return_type()).unwrap_or(ApiAttributeType::OBJECT)
+    }
+
+    fn clone_executor(&self, ctx: &Arc<SiddhiAppContext>) -> Box<dyn ExpressionExecutor> {
+        let mut cloned = Self::new(self.name, self.builder);
+        if let Some(exec) = &self.executor {
+            cloned.executor = Some(exec.clone_executor(ctx));
+        }
+        Box::new(cloned)
+    }
+}
+
+impl ScalarFunctionExecutor for BuiltinScalarFunction {
+    fn init(&mut self, args: &Vec<Box<dyn ExpressionExecutor>>, ctx: &Arc<SiddhiAppContext>) -> Result<(), String> {
+        let mut cloned: Vec<Box<dyn ExpressionExecutor>> = args.iter().map(|e| e.clone_executor(ctx)).collect();
+        let exec = (self.builder)(cloned)?;
+        self.executor = Some(exec);
+        Ok(())
+    }
+
+    fn destroy(&mut self) {
+        self.executor = None;
+    }
+
+    fn get_name(&self) -> String {
+        self.name.to_string()
+    }
+
+    fn clone_scalar_function(&self) -> Box<dyn ScalarFunctionExecutor> {
+        Box::new(Self::new(self.name, self.builder))
+    }
+}
+
+// --- Builtin builder helpers ---
+
+fn build_cast(args: Vec<Box<dyn ExpressionExecutor>>) -> Result<Box<dyn ExpressionExecutor>, String> {
+    if args.len() != 2 {
+        return Err("cast() requires two arguments".to_string());
+    }
+    let mut a = args;
+    let type_exec = a.remove(1);
+    let val_exec = a.remove(0);
+    Ok(Box::new(CastFunctionExecutor::new(val_exec, type_exec)?))
+}
+
+fn build_convert(args: Vec<Box<dyn ExpressionExecutor>>) -> Result<Box<dyn ExpressionExecutor>, String> {
+    if args.len() != 2 {
+        return Err("convert() requires two arguments".to_string());
+    }
+    let mut a = args;
+    let type_exec = a.remove(1);
+    let val_exec = a.remove(0);
+    Ok(Box::new(ConvertFunctionExecutor::new(val_exec, type_exec)?))
+}
+
+fn build_concat(args: Vec<Box<dyn ExpressionExecutor>>) -> Result<Box<dyn ExpressionExecutor>, String> {
+    Ok(Box::new(ConcatFunctionExecutor::new(args)?))
+}
+
+fn build_length(args: Vec<Box<dyn ExpressionExecutor>>) -> Result<Box<dyn ExpressionExecutor>, String> {
+    if args.len() != 1 { return Err("length() requires one argument".to_string()); }
+    Ok(Box::new(LengthFunctionExecutor::new(args.into_iter().next().unwrap())?))
+}
+
+fn build_coalesce(args: Vec<Box<dyn ExpressionExecutor>>) -> Result<Box<dyn ExpressionExecutor>, String> {
+    Ok(Box::new(CoalesceFunctionExecutor::new(args)?))
+}
+
+fn build_if_then_else(mut args: Vec<Box<dyn ExpressionExecutor>>) -> Result<Box<dyn ExpressionExecutor>, String> {
+    if args.len() != 3 { return Err("ifThenElse() requires three arguments".to_string()); }
+    let else_e = args.remove(2);
+    let then_e = args.remove(1);
+    let cond_e = args.remove(0);
+    Ok(Box::new(IfThenElseFunctionExecutor::new(cond_e, then_e, else_e)?))
+}
+
+fn build_uuid(_args: Vec<Box<dyn ExpressionExecutor>>) -> Result<Box<dyn ExpressionExecutor>, String> {
+    Ok(Box::new(UuidFunctionExecutor::new()))
+}
+
+fn build_current_timestamp(_args: Vec<Box<dyn ExpressionExecutor>>) -> Result<Box<dyn ExpressionExecutor>, String> {
+    Ok(Box::new(CurrentTimestampFunctionExecutor::default()))
+}
+
+fn build_format_date(mut args: Vec<Box<dyn ExpressionExecutor>>) -> Result<Box<dyn ExpressionExecutor>, String> {
+    if args.len() != 2 { return Err("formatDate() requires two arguments".to_string()); }
+    let pattern = args.remove(1);
+    let ts = args.remove(0);
+    Ok(Box::new(FormatDateFunctionExecutor::new(ts, pattern)?))
+}
+
+fn build_round(args: Vec<Box<dyn ExpressionExecutor>>) -> Result<Box<dyn ExpressionExecutor>, String> {
+    if args.len() != 1 { return Err("round() requires one argument".to_string()); }
+    Ok(Box::new(RoundFunctionExecutor::new(args.into_iter().next().unwrap())?))
+}
+
+fn build_sqrt(args: Vec<Box<dyn ExpressionExecutor>>) -> Result<Box<dyn ExpressionExecutor>, String> {
+    if args.len() != 1 { return Err("sqrt() requires one argument".to_string()); }
+    Ok(Box::new(SqrtFunctionExecutor::new(args.into_iter().next().unwrap())?))
+}
+
+fn build_event_timestamp(args: Vec<Box<dyn ExpressionExecutor>>) -> Result<Box<dyn ExpressionExecutor>, String> {
+    if args.is_empty() {
+        Ok(Box::new(EventTimestampFunctionExecutor::new(None)))
+    } else if args.len() == 1 {
+        Ok(Box::new(EventTimestampFunctionExecutor::new(Some(args.into_iter().next().unwrap()))))
+    } else {
+        Err("eventTimestamp() takes zero or one argument".to_string())
+    }
+}
+
+/// Register default builtin scalar functions into the provided SiddhiContext.
+pub fn register_builtin_scalar_functions(ctx: &crate::core::config::siddhi_context::SiddhiContext) {
+    ctx.add_scalar_function_factory("cast".to_string(), Box::new(BuiltinScalarFunction::new("cast", build_cast)));
+    ctx.add_scalar_function_factory("convert".to_string(), Box::new(BuiltinScalarFunction::new("convert", build_convert)));
+    ctx.add_scalar_function_factory("concat".to_string(), Box::new(BuiltinScalarFunction::new("concat", build_concat)));
+    ctx.add_scalar_function_factory("str:concat".to_string(), Box::new(BuiltinScalarFunction::new("str:concat", build_concat)));
+    ctx.add_scalar_function_factory("length".to_string(), Box::new(BuiltinScalarFunction::new("length", build_length)));
+    ctx.add_scalar_function_factory("str:length".to_string(), Box::new(BuiltinScalarFunction::new("str:length", build_length)));
+    ctx.add_scalar_function_factory("coalesce".to_string(), Box::new(BuiltinScalarFunction::new("coalesce", build_coalesce)));
+    ctx.add_scalar_function_factory("ifThenElse".to_string(), Box::new(BuiltinScalarFunction::new("ifThenElse", build_if_then_else)));
+    ctx.add_scalar_function_factory("uuid".to_string(), Box::new(BuiltinScalarFunction::new("uuid", build_uuid)));
+    ctx.add_scalar_function_factory("currentTimestamp".to_string(), Box::new(BuiltinScalarFunction::new("currentTimestamp", build_current_timestamp)));
+    ctx.add_scalar_function_factory("time:currentTimestamp".to_string(), Box::new(BuiltinScalarFunction::new("time:currentTimestamp", build_current_timestamp)));
+    ctx.add_scalar_function_factory("formatDate".to_string(), Box::new(BuiltinScalarFunction::new("formatDate", build_format_date)));
+    ctx.add_scalar_function_factory("time:formatDate".to_string(), Box::new(BuiltinScalarFunction::new("time:formatDate", build_format_date)));
+    ctx.add_scalar_function_factory("round".to_string(), Box::new(BuiltinScalarFunction::new("round", build_round)));
+    ctx.add_scalar_function_factory("math:round".to_string(), Box::new(BuiltinScalarFunction::new("math:round", build_round)));
+    ctx.add_scalar_function_factory("sqrt".to_string(), Box::new(BuiltinScalarFunction::new("sqrt", build_sqrt)));
+    ctx.add_scalar_function_factory("math:sqrt".to_string(), Box::new(BuiltinScalarFunction::new("math:sqrt", build_sqrt)));
+    ctx.add_scalar_function_factory("eventTimestamp".to_string(), Box::new(BuiltinScalarFunction::new("eventTimestamp", build_event_timestamp)));
+}

--- a/siddhi_rust/src/core/executor/function/convert_function_executor.rs
+++ b/siddhi_rust/src/core/executor/function/convert_function_executor.rs
@@ -1,0 +1,59 @@
+use crate::core::executor::expression_executor::ExpressionExecutor;
+use crate::core::event::complex_event::ComplexEvent;
+use crate::core::event::value::AttributeValue;
+use crate::query_api::definition::attribute::Type as ApiAttributeType;
+use crate::core::config::siddhi_app_context::SiddhiAppContext;
+use crate::core::util::attribute_converter::get_property_value;
+use std::sync::Arc;
+
+#[derive(Debug)]
+pub struct ConvertFunctionExecutor {
+    value_executor: Box<dyn ExpressionExecutor>,
+    target_type: ApiAttributeType,
+}
+
+impl ConvertFunctionExecutor {
+    pub fn new(
+        value_executor: Box<dyn ExpressionExecutor>,
+        type_executor: Box<dyn ExpressionExecutor>,
+    ) -> Result<Self, String> {
+        if type_executor.get_return_type() != ApiAttributeType::STRING {
+            return Err("convert() type argument must be STRING".to_string());
+        }
+        let type_val = match type_executor.execute(None) {
+            Some(AttributeValue::String(s)) => s.to_lowercase(),
+            _ => return Err("convert() requires constant type string".to_string()),
+        };
+        let target_type = match type_val.as_str() {
+            "string" => ApiAttributeType::STRING,
+            "int" => ApiAttributeType::INT,
+            "long" => ApiAttributeType::LONG,
+            "float" => ApiAttributeType::FLOAT,
+            "double" => ApiAttributeType::DOUBLE,
+            "bool" | "boolean" => ApiAttributeType::BOOL,
+            _ => return Err(format!("Unsupported convert target type: {}", type_val)),
+        };
+        Ok(Self { value_executor, target_type })
+    }
+}
+
+impl ExpressionExecutor for ConvertFunctionExecutor {
+    fn execute(&self, event: Option<&dyn ComplexEvent>) -> Option<AttributeValue> {
+        let value = self.value_executor.execute(event)?;
+        match get_property_value(value, self.target_type.clone()) {
+            Ok(v) => Some(v),
+            Err(_) => None,
+        }
+    }
+
+    fn get_return_type(&self) -> ApiAttributeType {
+        self.target_type
+    }
+
+    fn clone_executor(&self, ctx: &Arc<SiddhiAppContext>) -> Box<dyn ExpressionExecutor> {
+        Box::new(ConvertFunctionExecutor {
+            value_executor: self.value_executor.clone_executor(ctx),
+            target_type: self.target_type,
+        })
+    }
+}

--- a/siddhi_rust/src/core/executor/function/event_timestamp_function_executor.rs
+++ b/siddhi_rust/src/core/executor/function/event_timestamp_function_executor.rs
@@ -1,0 +1,38 @@
+use crate::core::executor::expression_executor::ExpressionExecutor;
+use crate::core::event::complex_event::ComplexEvent;
+use crate::core::event::value::AttributeValue;
+use crate::query_api::definition::attribute::Type as ApiAttributeType;
+use crate::core::config::siddhi_app_context::SiddhiAppContext;
+use std::sync::Arc;
+
+#[derive(Debug, Default)]
+pub struct EventTimestampFunctionExecutor {
+    event_executor: Option<Box<dyn ExpressionExecutor>>,
+}
+
+impl EventTimestampFunctionExecutor {
+    pub fn new(event_executor: Option<Box<dyn ExpressionExecutor>>) -> Self {
+        Self { event_executor }
+    }
+}
+
+impl ExpressionExecutor for EventTimestampFunctionExecutor {
+    fn execute(&self, event: Option<&dyn ComplexEvent>) -> Option<AttributeValue> {
+        if self.event_executor.is_some() {
+            // simplified: not supporting explicit event argument yet
+            None
+        } else {
+            Some(AttributeValue::Long(event?.get_timestamp()))
+        }
+    }
+
+    fn get_return_type(&self) -> ApiAttributeType {
+        ApiAttributeType::LONG
+    }
+
+    fn clone_executor(&self, ctx: &Arc<SiddhiAppContext>) -> Box<dyn ExpressionExecutor> {
+        Box::new(EventTimestampFunctionExecutor {
+            event_executor: self.event_executor.as_ref().map(|e| e.clone_executor(ctx)),
+        })
+    }
+}

--- a/siddhi_rust/src/core/executor/function/mod.rs
+++ b/siddhi_rust/src/core/executor/function/mod.rs
@@ -6,6 +6,9 @@ pub mod instance_of_checkers;
 pub mod uuid_function_executor;
 pub mod scalar_function_executor; // Added
 pub mod cast_function_executor;
+pub mod convert_function_executor;
+pub mod event_timestamp_function_executor;
+pub mod builtin_wrapper;
 pub mod string_functions;
 pub mod date_functions;
 pub mod math_functions;
@@ -18,6 +21,9 @@ pub use self::instance_of_checkers::*;
 pub use self::uuid_function_executor::UuidFunctionExecutor;
 pub use self::scalar_function_executor::ScalarFunctionExecutor; // Added
 pub use self::cast_function_executor::CastFunctionExecutor;
+pub use self::convert_function_executor::ConvertFunctionExecutor;
+pub use self::event_timestamp_function_executor::EventTimestampFunctionExecutor;
+pub use self::builtin_wrapper::{BuiltinScalarFunction, BuiltinBuilder};
 pub use self::string_functions::{ConcatFunctionExecutor, LengthFunctionExecutor};
 pub use self::date_functions::{CurrentTimestampFunctionExecutor, FormatDateFunctionExecutor};
 pub use self::math_functions::{RoundFunctionExecutor, SqrtFunctionExecutor};

--- a/siddhi_rust/src/query_compiler/grammar.lalrpop
+++ b/siddhi_rust/src/query_compiler/grammar.lalrpop
@@ -413,6 +413,7 @@ PrimaryExpr: Expression = {
     <n:NUMBER> => Expression::value_long(n),
     "-" <n:NUMBER> => Expression::value_long(-n),
     <sid:Ident> "." <id:Ident> => Expression::Variable(Variable::new(id).of_stream(sid)),
+    <ns:Ident> ":" <id:Ident> "(" <args:ExprList> ")" => Expression::function(Some(ns), id, args),
     <id:Ident> "(" <args:ExprList> ")" => Expression::function_no_ns(id, args),
     <id:Ident> => Expression::variable(id),
 };

--- a/siddhi_rust/tests/parser_tests.rs
+++ b/siddhi_rust/tests/parser_tests.rs
@@ -62,3 +62,79 @@ fn test_join_query() {
     let out = runner.shutdown();
     assert_eq!(out, vec![vec![AttributeValue::Int(5), AttributeValue::Int(5)]]);
 }
+
+#[test]
+fn test_builtin_function_in_query() {
+    let app = "\
+        define stream In (v string);\n\
+        define stream Out (len int);\n\
+        from In select str:length(v) as len insert into Out;\n";
+    let runner = AppRunner::new(app, "Out");
+    runner.send("In", vec![AttributeValue::String("abc".to_string())]);
+    let out = runner.shutdown();
+    assert_eq!(out, vec![vec![AttributeValue::Int(3)]]);
+}
+
+#[test]
+fn test_udf_in_query() {
+    use siddhi_rust::core::siddhi_manager::SiddhiManager;
+    use siddhi_rust::core::executor::expression_executor::ExpressionExecutor;
+    use siddhi_rust::core::executor::function::scalar_function_executor::ScalarFunctionExecutor;
+    use siddhi_rust::query_api::definition::attribute::Type as AttrType;
+    use siddhi_rust::core::config::siddhi_app_context::SiddhiAppContext;
+    use siddhi_rust::query_compiler::parse;
+    use siddhi_rust::query_api::siddhi_app::SiddhiApp;
+    use std::sync::Arc;
+
+    #[derive(Debug, Default)]
+    struct PlusOneFn { arg: Option<Box<dyn ExpressionExecutor>> }
+
+    impl Clone for PlusOneFn { fn clone(&self) -> Self { Self { arg: None } } }
+
+    impl ExpressionExecutor for PlusOneFn {
+        fn execute(&self, event: Option<&dyn siddhi_rust::core::event::complex_event::ComplexEvent>) -> Option<AttributeValue> {
+            let v = self.arg.as_ref()?.execute(event)?;
+            match v { AttributeValue::Int(i) => Some(AttributeValue::Int(i+1)), _ => None }
+        }
+        fn get_return_type(&self) -> AttrType { AttrType::INT }
+        fn clone_executor(&self, _ctx:&Arc<SiddhiAppContext>) -> Box<dyn ExpressionExecutor> { Box::new(self.clone()) }
+    }
+    impl ScalarFunctionExecutor for PlusOneFn {
+        fn init(&mut self, args:&Vec<Box<dyn ExpressionExecutor>>, ctx:&Arc<SiddhiAppContext>) -> Result<(), String> {
+            if args.len()!=1 { return Err("plusOne expects one argument".to_string()); }
+            self.arg = Some(args[0].clone_executor(ctx));
+            Ok(())
+        }
+        fn destroy(&mut self) {}
+        fn get_name(&self) -> String { "plusOne".to_string() }
+        fn clone_scalar_function(&self) -> Box<dyn ScalarFunctionExecutor> { Box::new(self.clone()) }
+    }
+
+    let manager = SiddhiManager::new();
+    manager.add_scalar_function_factory("plusOne".to_string(), Box::new(PlusOneFn::default()));
+
+    let app_str = "\
+        define stream In (v int);\n\
+        define stream Out (v int);\n\
+        from In select plusOne(v) as v insert into Out;\n";
+    use siddhi_rust::core::stream::output::stream_callback::StreamCallback;
+    use siddhi_rust::core::event::event::Event;
+    use std::sync::Mutex;
+
+    #[derive(Debug)]
+    struct CollectCB { ev: Arc<Mutex<Vec<Vec<AttributeValue>>>> }
+    impl StreamCallback for CollectCB {
+        fn receive_events(&self, events: &[Event]) { self.ev.lock().unwrap().extend(events.iter().map(|e| e.data.clone())); }
+    }
+
+    let api = parse(app_str).unwrap();
+    let runtime = manager.create_siddhi_app_runtime_from_api(Arc::new(api), None).unwrap();
+    let collected = Arc::new(Mutex::new(Vec::new()));
+    runtime.add_callback("Out", Box::new(CollectCB { ev: Arc::clone(&collected) })).unwrap();
+    runtime.start();
+    let handler = runtime.get_input_handler("In").unwrap();
+    handler.lock().unwrap().send_event_with_timestamp(0, vec![AttributeValue::Int(4)]).unwrap();
+    runtime.shutdown();
+    let out = collected.lock().unwrap().clone();
+    assert_eq!(out, vec![vec![AttributeValue::Int(5)]]);
+}


### PR DESCRIPTION
## Summary
- map built-in function names to factories in `SiddhiContext`
- support `namespace:function` syntax in grammar
- generate executors for built-ins via a generic wrapper
- add convert and eventTimestamp executors
- test built-in and custom UDF usage in queries

## Testing
- `cargo test --tests`

------
https://chatgpt.com/codex/tasks/task_e_684ba65d0d048325b315c7211a8b9600