### PR TITLE
Add incremental aggregation execution

### DIFF
--- a/siddhi_rust/src/core/aggregation/aggregation_runtime.rs
+++ b/siddhi_rust/src/core/aggregation/aggregation_runtime.rs
@@ -5,22 +5,40 @@ use crate::core::event::stream::stream_event::StreamEvent;
 use crate::query_api::aggregation::time_period::Duration as TimeDuration;
 
 use super::incremental_executor::IncrementalExecutor;
+use crate::core::table::{InMemoryTable, Table};
 
 #[derive(Debug)]
 pub struct AggregationRuntime {
     pub name: String,
     pub executors: HashMap<TimeDuration, Arc<IncrementalExecutor>>, // root executor by duration
+    pub tables: HashMap<TimeDuration, Arc<InMemoryTable>>, // aggregated data
 }
 
 impl AggregationRuntime {
     pub fn new(name: String, executors: HashMap<TimeDuration, Arc<IncrementalExecutor>>) -> Self {
-        Self { name, executors }
+        Self { name, executors, tables: HashMap::new() }
     }
 
     pub fn process(&self, event: &StreamEvent) {
         // For now, always use the smallest duration executor
         if let Some(exec) = self.executors.values().next() {
             exec.execute(event);
+        }
+    }
+
+    pub fn add_table(&mut self, dur: TimeDuration, table: Arc<InMemoryTable>) {
+        self.tables.insert(dur, table);
+    }
+
+    pub fn get_table(&self, dur: TimeDuration) -> Option<Arc<InMemoryTable>> {
+        self.tables.get(&dur).cloned()
+    }
+
+    pub fn query_all(&self, dur: TimeDuration) -> Vec<Vec<crate::core::event::value::AttributeValue>> {
+        if let Some(table) = self.tables.get(&dur) {
+            table.all_rows()
+        } else {
+            Vec::new()
         }
     }
 }

--- a/siddhi_rust/src/core/aggregation/base_incremental_value_store.rs
+++ b/siddhi_rust/src/core/aggregation/base_incremental_value_store.rs
@@ -50,4 +50,13 @@ impl BaseIncrementalValueStore {
         }
         out
     }
+
+    /// Drain all grouped values returning the timestamp and the values.
+    /// This clears the internal storage.
+    pub fn drain_grouped_values(&self) -> (i64, HashMap<String, Vec<AttributeValue>>) {
+        let mut map = self.grouped_values.lock().unwrap();
+        let ts = *self.timestamp.lock().unwrap();
+        let out = std::mem::take(&mut *map);
+        (ts, out)
+    }
 }

--- a/siddhi_rust/src/core/aggregation/incremental_data_aggregator.rs
+++ b/siddhi_rust/src/core/aggregation/incremental_data_aggregator.rs
@@ -1,8 +1,16 @@
+use crate::core::event::value::AttributeValue;
+use super::aggregation_runtime::AggregationRuntime;
+use crate::query_api::aggregation::time_period::Duration as TimeDuration;
+
 #[derive(Debug, Default)]
 pub struct IncrementalDataAggregator;
 
 impl IncrementalDataAggregator {
     pub fn new() -> Self {
         Self {}
+    }
+
+    pub fn aggregate(runtime: &AggregationRuntime, duration: TimeDuration) -> Vec<Vec<AttributeValue>> {
+        runtime.query_all(duration)
     }
 }

--- a/siddhi_rust/src/core/aggregation/incremental_executor.rs
+++ b/siddhi_rust/src/core/aggregation/incremental_executor.rs
@@ -1,17 +1,19 @@
-use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use crate::core::event::stream::stream_event::StreamEvent;
 use crate::core::executor::expression_executor::ExpressionExecutor;
 use crate::query_api::aggregation::time_period::Duration as TimeDuration;
 
 use super::base_incremental_value_store::BaseIncrementalValueStore;
+use crate::core::table::{InMemoryTable, Table};
 
 pub struct IncrementalExecutor {
     pub duration: TimeDuration,
     pub base_store: Arc<BaseIncrementalValueStore>,
     pub next: Option<Arc<IncrementalExecutor>>, // simplified chain
     pub group_by_fn: Box<dyn Fn(&StreamEvent) -> String + Send + Sync>,
+    pub bucket_start: Mutex<i64>,
+    pub table: Arc<InMemoryTable>,
 }
 
 impl std::fmt::Debug for IncrementalExecutor {
@@ -27,23 +29,54 @@ impl IncrementalExecutor {
         duration: TimeDuration,
         executors: Vec<Box<dyn ExpressionExecutor>>,
         group_by_fn: Box<dyn Fn(&StreamEvent) -> String + Send + Sync>,
+        table: Arc<InMemoryTable>,
     ) -> Self {
         Self {
             duration,
             base_store: Arc::new(BaseIncrementalValueStore::new(executors)),
             next: None,
             group_by_fn,
+            bucket_start: Mutex::new(-1),
+            table,
+        }
+    }
+
+    fn bucket_ms(&self) -> i64 {
+        self.duration.to_millis() as i64
+    }
+
+    fn flush(&self, bucket_start: i64) {
+        let (_timestamp, groups) = self.base_store.drain_grouped_values();
+        for (_k, values) in groups.into_iter() {
+            println!("flush {:?} -> {:?}", self.duration, values);
+            let mut ev = StreamEvent::new(bucket_start, 0, 0, values.len());
+            ev.output_data = Some(values.clone());
+            self.table.insert(&values);
+            if let Some(ref next) = self.next {
+                next.execute(&ev);
+            }
+        }
+        // reset aggregators for next bucket
+        use crate::core::event::complex_event::{ComplexEventType, ComplexEvent};
+        for exec in &self.base_store.expression_executors {
+            let mut r = StreamEvent::new(bucket_start,0,0,0);
+            r.set_event_type(ComplexEventType::Reset);
+            exec.execute(Some(&r));
         }
     }
 
     pub fn execute(&self, event: &StreamEvent) {
+        let mut start = self.bucket_start.lock().unwrap();
+        if *start == -1 {
+            *start = event.timestamp - (event.timestamp % self.bucket_ms());
+        }
+        while event.timestamp >= *start + self.bucket_ms() {
+            let b_start = *start;
+            *start += self.bucket_ms();
+            self.flush(b_start);
+        }
+
         let key = (self.group_by_fn)(event);
         self.base_store.process(&key, event);
-        if let Some(ref next) = self.next {
-            for (_, ev) in self.base_store.get_grouped_events().into_iter() {
-                next.execute(&ev);
-            }
-            self.base_store.clear();
-        }
     }
 }

--- a/siddhi_rust/src/core/table/mod.rs
+++ b/siddhi_rust/src/core/table/mod.rs
@@ -48,6 +48,10 @@ impl InMemoryTable {
     pub fn new() -> Self {
         Self { rows: RwLock::new(Vec::new()) }
     }
+
+    pub fn all_rows(&self) -> Vec<Vec<AttributeValue>> {
+        self.rows.read().unwrap().clone()
+    }
 }
 
 impl Table for InMemoryTable {

--- a/siddhi_rust/src/query_api/aggregation/time_period.rs
+++ b/siddhi_rust/src/query_api/aggregation/time_period.rs
@@ -12,6 +12,30 @@ pub enum Duration {
     Years,
 }
 
+impl Duration {
+    pub fn to_millis(self) -> u64 {
+        match self {
+            Duration::Seconds => 1000,
+            Duration::Minutes => 60_000,
+            Duration::Hours => 3_600_000,
+            Duration::Days => 86_400_000,
+            Duration::Months => 2_592_000_000,
+            Duration::Years => 31_536_000_000,
+        }
+    }
+
+    pub fn next(self) -> Option<Duration> {
+        match self {
+            Duration::Seconds => Some(Duration::Minutes),
+            Duration::Minutes => Some(Duration::Hours),
+            Duration::Hours => Some(Duration::Days),
+            Duration::Days => Some(Duration::Months),
+            Duration::Months => Some(Duration::Years),
+            Duration::Years => None,
+        }
+    }
+}
+
 impl Default for Duration {
     fn default() -> Self { Duration::Seconds }
 }

--- a/siddhi_rust/tests/incremental_aggregation.rs
+++ b/siddhi_rust/tests/incremental_aggregation.rs
@@ -1,0 +1,65 @@
+#[path = "common/mod.rs"]
+mod common;
+use siddhi_rust::core::aggregation::IncrementalExecutor;
+use siddhi_rust::core::util::parser::{parse_expression, ExpressionParserContext};
+use siddhi_rust::core::config::{siddhi_app_context::SiddhiAppContext, siddhi_context::SiddhiContext, siddhi_query_context::SiddhiQueryContext};
+use siddhi_rust::query_api::siddhi_app::SiddhiApp;
+use siddhi_rust::query_api::definition::{StreamDefinition, attribute::Type as AttrType};
+use siddhi_rust::core::event::stream::meta_stream_event::MetaStreamEvent;
+use siddhi_rust::core::event::stream::stream_event::StreamEvent;
+use siddhi_rust::core::event::value::AttributeValue;
+use siddhi_rust::query_api::expression::{Expression, variable::Variable};
+use siddhi_rust::core::table::InMemoryTable;
+use siddhi_rust::query_api::aggregation::time_period::Duration as TimeDuration;
+use std::sync::Arc;
+use std::collections::HashMap;
+
+fn make_ctx(name: &str) -> ExpressionParserContext<'static> {
+    let app_ctx = Arc::new(SiddhiAppContext::new(
+        Arc::new(SiddhiContext::default()),
+        "app".to_string(),
+        Arc::new(SiddhiApp::new("app".to_string())),
+        String::new(),
+    ));
+    let q_ctx = Arc::new(SiddhiQueryContext::new(Arc::clone(&app_ctx), name.to_string(), None));
+    let stream_def = Arc::new(
+        StreamDefinition::new("InStream".to_string())
+            .attribute("value".to_string(), AttrType::INT),
+    );
+    let meta = MetaStreamEvent::new_for_single_input(Arc::clone(&stream_def));
+    let mut stream_map = HashMap::new();
+    stream_map.insert("InStream".to_string(), Arc::new(meta));
+    let qn: &'static str = Box::leak(name.to_string().into_boxed_str());
+    ExpressionParserContext {
+        siddhi_app_context: Arc::clone(&app_ctx),
+        siddhi_query_context: q_ctx,
+        stream_meta_map: stream_map,
+        table_meta_map: HashMap::new(),
+        window_meta_map: HashMap::new(),
+        state_meta_map: HashMap::new(),
+        default_source: "InStream".to_string(),
+        query_name: qn,
+    }
+}
+
+#[test]
+fn test_incremental_executor_basic() {
+    let ctx = make_ctx("inc");
+    let expr = Expression::function_no_ns(
+        "sum".to_string(),
+        vec![Expression::Variable(Variable::new("value".to_string()))],
+    );
+    let exec = parse_expression(&expr, &ctx).unwrap();
+    let table = Arc::new(InMemoryTable::new());
+    let mut inc = IncrementalExecutor::new(TimeDuration::Seconds, vec![exec], Box::new(|_| "key".to_string()), Arc::clone(&table));
+    let mut e1 = StreamEvent::new(0,1,0,0);
+    e1.before_window_data[0] = AttributeValue::Int(1);
+    inc.execute(&e1);
+    let mut e2 = StreamEvent::new(1500,1,0,0);
+    e2.before_window_data[0] = AttributeValue::Int(2);
+    inc.execute(&e2);
+    // flush last bucket
+    inc.execute(&StreamEvent::new(2000,1,0,0));
+    let rows = table.all_rows();
+    assert_eq!(rows, vec![vec![AttributeValue::Long(1)], vec![AttributeValue::Long(2)]]);
+}


### PR DESCRIPTION
## Summary
- flesh out IncrementalExecutor and related types
- add simple AggregationRuntime tables and query helpers
- expose Duration helpers
- add unit test for IncrementalExecutor aggregation

## Testing
- `cargo test --test incremental_aggregation -- --nocapture`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684baafdc6588325b326a6cd302f4bc2