### PR TITLE
Implement partition parsing

### DIFF
--- a/siddhi_rust/src/query_compiler/grammar.lalrpop
+++ b/siddhi_rust/src/query_compiler/grammar.lalrpop
@@ -26,6 +26,10 @@ use crate::query_api::expression::condition::compare::Operator as CompareOperato
 use crate::query_api::aggregation::TimePeriod;
 use crate::query_api::aggregation::time_period::Duration as TimeDuration;
 use crate::query_api::annotation::Annotation;
+use crate::query_api::execution::{
+    Partition, PartitionType, RangePartitionProperty, RangePartitionType,
+    ValuePartitionType,
+};
 
 pub AnnotationStmt: Annotation = {
     "@" <name:Ident> ":" <key:Ident> "(" <val:STRING> ")" => {
@@ -312,6 +316,39 @@ pub QueryStmt: Query = {
         Query::query().from(in_stream).select(selector).out_stream(output_stream)
     }
 };
+
+
+pub PartitionStmt: Partition = {
+    "partition" "with" "(" <first:PartitionWithStream> <rest:("," PartitionWithStream)*> ")" "begin" <qs:QueryList> "end" => {
+        let mut p = Partition::partition().with_partition_type(first);
+        for (_, pt) in rest { p = p.with_partition_type(pt); }
+        for q in qs { p = p.add_query(q); }
+        p
+    }
+};
+
+QueryList: Vec<Query> = {
+    <first:QueryStmt> <rest:(";" QueryStmt)*> ";"? => {
+        let mut v = vec![first];
+        for (_, q) in rest { v.push(q); }
+        v
+    }
+};
+
+PartitionWithStream: PartitionType = {
+    <expr:Expression> "of" <sid:Ident> => PartitionType::new_value(ValuePartitionType::new(sid, expr)),
+    <cr:ConditionRanges> "of" <sid:Ident> => PartitionType::new_range(RangePartitionType::new(sid, cr)),
+};
+
+ConditionRanges: Vec<RangePartitionProperty> = {
+    <first:ConditionRange> <rest:("or" ConditionRange)*> => {
+        let mut v = vec![first];
+        for (_, c) in rest { v.push(c); }
+        v
+    }
+};
+
+ConditionRange: RangePartitionProperty = { <expr:Expression> "as" <key:STRING> => RangePartitionProperty::new(key, expr) };
 
 
 SelectList: Vec<(Expression, Option<String>)> = {

--- a/siddhi_rust/tests/partition.rs
+++ b/siddhi_rust/tests/partition.rs
@@ -1,0 +1,26 @@
+use siddhi_rust::query_compiler::{parse, parse_partition};
+use siddhi_rust::query_api::execution::ExecutionElement;
+
+#[test]
+fn test_parse_partition_direct() {
+    let part = "partition with (symbol of InStream) begin from InStream select sum(volume) as sumvolume insert into OutStream; end";
+    let p = parse_partition(part).expect("parse partition");
+    assert_eq!(p.query_list.len(), 1);
+    assert_eq!(p.partition_type_map.len(), 1);
+}
+
+#[test]
+fn test_parse_app_with_partition() {
+    let app = "\
+        define stream InStream (symbol string, volume int);\n\
+        define stream OutStream (sumvolume long);\n\
+        partition with (symbol of InStream) begin from InStream select sum(volume) as sumvolume insert into OutStream; end;\n";
+    let sa = parse(app).expect("parse");
+    assert_eq!(sa.get_execution_elements().len(), 1);
+    match &sa.get_execution_elements()[0] {
+        ExecutionElement::Partition(p) => {
+            assert_eq!(p.query_list.len(), 1);
+        }
+        _ => panic!("expected partition"),
+    }
+}


### PR DESCRIPTION
## Summary
- handle partitions in Siddhi compiler grammar
- support `parse_partition` and parse apps containing `partition` blocks
- test direct and app-level partition parsing

## Testing
- `cargo test partition -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_684bae5de980832590b314d22549653e