### PR TITLE
Add partition runtime parser

### DIFF
--- a/siddhi_rust/src/core/partition/mod.rs
+++ b/siddhi_rust/src/core/partition/mod.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crate::core::query::query_runtime::QueryRuntime;
+use crate::core::query::query_runtime::{QueryRuntime, QueryRuntimeTrait};
 
 /// Runtime representation of a Partition.
 #[derive(Debug, Default)]
@@ -16,4 +16,13 @@ impl PartitionRuntime {
     pub fn add_query_runtime(&mut self, qr: Arc<QueryRuntime>) {
         self.query_runtimes.push(qr);
     }
+
+    pub fn start(&self) {
+        for qr in &self.query_runtimes {
+            println!("Starting query runtime {} in partition", qr.get_query_id());
+        }
+    }
 }
+
+pub mod parser;
+pub use parser::PartitionParser;

--- a/siddhi_rust/src/core/partition/parser.rs
+++ b/siddhi_rust/src/core/partition/parser.rs
@@ -1,15 +1,10 @@
-// siddhi_rust/src/core/util/parser/partition_parser.rs
-// Simplified PartitionParser placeholder
-use std::sync::{Arc, Mutex};
-use std::collections::HashMap;
+use std::sync::Arc;
 
 use crate::query_api::execution::partition::Partition as ApiPartition;
-use crate::query_api::execution::ExecutionElement;
 use crate::core::config::siddhi_app_context::SiddhiAppContext;
 use crate::core::siddhi_app_runtime_builder::SiddhiAppRuntimeBuilder;
 use crate::core::partition::PartitionRuntime;
-use crate::core::stream::stream_junction::StreamJunction;
-use super::query_parser::QueryParser;
+use crate::core::util::parser::QueryParser;
 
 pub struct PartitionParser;
 

--- a/siddhi_rust/src/core/siddhi_app_runtime.rs
+++ b/siddhi_rust/src/core/siddhi_app_runtime.rs
@@ -10,6 +10,7 @@ use crate::core::stream::input::input_handler::InputHandler;
 use std::sync::{Arc, Mutex};
 use crate::core::stream::output::stream_callback::StreamCallback; // The trait
 use crate::core::query::query_runtime::QueryRuntime;
+use crate::core::partition::PartitionRuntime;
 use crate::core::util::parser::SiddhiAppParser; // For SiddhiAppParser::parse_siddhi_app_runtime_builder
 use crate::core::siddhi_app_runtime_builder::SiddhiAppRuntimeBuilder;
 use crate::core::query::output::callback_processor::CallbackProcessor; // To be created
@@ -30,6 +31,7 @@ pub struct SiddhiAppRuntime {
     pub stream_junction_map: HashMap<String, Arc<Mutex<StreamJunction>>>,
     pub input_manager: Arc<InputManager>,
     pub query_runtimes: Vec<Arc<QueryRuntime>>,
+    pub partition_runtimes: Vec<Arc<PartitionRuntime>>,
     pub scheduler: Option<Arc<crate::core::util::Scheduler>>,
     pub aggregation_map: HashMap<String, Arc<Mutex<crate::core::aggregation::AggregationRuntime>>>,
     // TODO: Add other runtime component maps (tables, windows, partitions, triggers)
@@ -142,6 +144,9 @@ impl SiddhiAppRuntime {
         if let Some(scheduler) = &self.scheduler {
             // placeholder: scheduler is kept alive by self
             println!("Scheduler initialized for SiddhiAppRuntime '{}'", self.name);
+        }
+        for pr in &self.partition_runtimes {
+            pr.start();
         }
         println!("SiddhiAppRuntime '{}' started", self.name);
     }

--- a/siddhi_rust/src/core/siddhi_app_runtime_builder.rs
+++ b/siddhi_rust/src/core/siddhi_app_runtime_builder.rs
@@ -119,6 +119,7 @@ impl SiddhiAppRuntimeBuilder {
             stream_junction_map: self.stream_junction_map,
             input_manager: Arc::new(input_manager),
             query_runtimes: self.query_runtimes,
+            partition_runtimes: self.partition_runtimes,
             scheduler: Some(scheduler),
             aggregation_map,
             // Initialize other runtime fields (tables, windows, partitions, triggers)

--- a/siddhi_rust/src/core/util/parser/mod.rs
+++ b/siddhi_rust/src/core/util/parser/mod.rs
@@ -3,7 +3,6 @@
 pub mod expression_parser;
 pub mod query_parser; // Added
 pub mod siddhi_app_parser; // Added
-pub mod partition_parser;
 // Other parsers will be added here later:
 // pub mod aggregation_parser;
 // ... etc.
@@ -11,4 +10,4 @@ pub mod partition_parser;
 pub use self::expression_parser::{parse_expression, ExpressionParserContext};
 pub use self::query_parser::QueryParser; // Added
 pub use self::siddhi_app_parser::SiddhiAppParser; // Added
-pub use self::partition_parser::PartitionParser;
+pub use crate::core::partition::parser::PartitionParser;

--- a/siddhi_rust/src/core/util/parser/siddhi_app_parser.rs
+++ b/siddhi_rust/src/core/util/parser/siddhi_app_parser.rs
@@ -17,49 +17,10 @@ use crate::core::aggregation::AggregationRuntime;
 use crate::core::stream::stream_junction::{StreamJunction, OnErrorAction}; // For creating junctions
 use crate::query_api::execution::query::input::stream::input_stream::InputStreamTrait;
 // use super::query_parser::QueryParser; // To be created or defined in this file for now
-// use super::partition_parser::PartitionParser; // To be created
+use crate::core::partition::parser::PartitionParser;
 // use super::definition_parser_helpers::*; // For defineStreamDefinitions, defineTableDefinitions etc.
 use crate::core::util::SiddhiConstants as CoreSiddhiConstants; // Core constants, if any, vs query_api constants
 use super::query_parser::QueryParser; // Use the real QueryParser implementation
-
-// Placeholder for QueryParser and PartitionParser logic
-// In a full system, these would be in their own modules.
-mod query_parser_placeholder {
-    use super::*;
-    use crate::query_api::execution::query::Query as ApiQuery;
-    use crate::core::query::query_runtime::QueryRuntime;
-    pub struct QueryParser;
-    impl QueryParser {
-        pub fn parse_query(
-            _api_query: &ApiQuery,
-            _siddhi_app_context: &Arc<SiddhiAppContext>,
-            _stream_junction_map: &mut HashMap<String, Arc<Mutex<StreamJunction>>>,
-            // _table_map: &HashMap<String, Arc<Mutex<crate::core::siddhi_app_runtime_builder::TableRuntimePlaceholder>>>,
-        ) -> Result<QueryRuntime, String> {
-            // Simplified: create a dummy QueryRuntime
-            let query_name = _api_query.get_query_name_placeholder().unwrap_or_else(|| "unknown_query".to_string());
-            let input_stream_id = _api_query.get_input_stream_id_placeholder().unwrap_or_else(|| "unknown_input".to_string());
-
-            let _input_junction = _stream_junction_map.get(&input_stream_id)
-                .ok_or_else(|| format!("Input stream '{}' not found for query '{}'", input_stream_id, query_name))?.clone();
-
-            let query_ctx = Arc::new(SiddhiQueryContext::new(
-                Arc::clone(_siddhi_app_context),
-                query_name.clone(),
-                None,
-            ));
-            Ok(QueryRuntime::new_with_context(query_name, Arc::new(_api_query.clone()), query_ctx))
-        }
-    }
-    // Placeholder getters on query_api::Query
-    impl ApiQuery {
-        fn get_query_name_placeholder(&self) -> Option<String> { Some("query1".to_string())} // Placeholder
-        fn get_input_stream_id_placeholder(&self) -> Option<String> {
-            self.input_stream.as_ref().map(|is| is.get_all_stream_ids().join(",")) // Simplified
-        }
-    }
-}
-
 
 pub struct SiddhiAppParser;
 
@@ -228,7 +189,7 @@ impl SiddhiAppParser {
                     // TODO: siddhi_app_context.addEternalReferencedHolder(queryRuntime);
                 }
                 ApiExecutionElement::Partition(api_partition) => {
-                    let part_rt = super::partition_parser::PartitionParser::parse(
+                    let part_rt = PartitionParser::parse(
                         &mut builder,
                         api_partition,
                         &siddhi_app_context,


### PR DESCRIPTION
## Summary
- implement `PartitionParser` in `core/partition` and expose it
- store partition runtimes in builder and runtime
- invoke `PartitionParser` from `SiddhiAppParser`
- remove obsolete placeholder parser module

## Testing
- `cargo check --manifest-path siddhi_rust/Cargo.toml`
- `cargo test --manifest-path siddhi_rust/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_684bf7c04bd88325b5fc7fa5cc1f4531