### PR TITLE
Implement window & aggregation runtime hooks

### DIFF
--- a/siddhi_rust/src/core/aggregation/aggregation_input_processor.rs
+++ b/siddhi_rust/src/core/aggregation/aggregation_input_processor.rs
@@ -1,0 +1,41 @@
+use crate::core::config::{siddhi_app_context::SiddhiAppContext, siddhi_query_context::SiddhiQueryContext};
+use crate::core::event::complex_event::ComplexEvent;
+use crate::core::event::stream::stream_event::StreamEvent;
+use crate::core::query::processor::{Processor, CommonProcessorMeta, ProcessingMode};
+use std::sync::{Arc, Mutex};
+
+use super::aggregation_runtime::AggregationRuntime;
+
+#[derive(Debug)]
+pub struct AggregationInputProcessor {
+    meta: CommonProcessorMeta,
+    runtime: Arc<Mutex<AggregationRuntime>>, // shared runtime
+}
+
+impl AggregationInputProcessor {
+    pub fn new(runtime: Arc<Mutex<AggregationRuntime>>, app_ctx: Arc<SiddhiAppContext>, query_ctx: Arc<SiddhiQueryContext>) -> Self {
+        Self { meta: CommonProcessorMeta::new(app_ctx, query_ctx), runtime }
+    }
+}
+
+impl Processor for AggregationInputProcessor {
+    fn process(&self, mut chunk: Option<Box<dyn ComplexEvent>>) {
+        while let Some(mut event) = chunk {
+            let next = event.set_next(None);
+            if let Some(se) = event.as_any().downcast_ref::<StreamEvent>() {
+                self.runtime.lock().unwrap().process(se);
+            }
+            chunk = next;
+        }
+    }
+
+    fn next_processor(&self) -> Option<Arc<Mutex<dyn Processor>>> { None }
+    fn set_next_processor(&mut self, _next: Option<Arc<Mutex<dyn Processor>>>) {}
+    fn clone_processor(&self, qctx: &Arc<SiddhiQueryContext>) -> Box<dyn Processor> {
+        Box::new(Self::new(Arc::clone(&self.runtime), Arc::clone(&self.meta.siddhi_app_context), Arc::clone(qctx)))
+    }
+    fn get_siddhi_app_context(&self) -> Arc<SiddhiAppContext> { Arc::clone(&self.meta.siddhi_app_context) }
+    fn get_processing_mode(&self) -> ProcessingMode { ProcessingMode::DEFAULT }
+    fn is_stateful(&self) -> bool { true }
+}
+

--- a/siddhi_rust/src/core/aggregation/mod.rs
+++ b/siddhi_rust/src/core/aggregation/mod.rs
@@ -4,6 +4,7 @@ pub mod incremental_executors_initialiser;
 pub mod incremental_data_aggregator;
 pub mod incremental_data_purger;
 pub mod aggregation_runtime;
+pub mod aggregation_input_processor;
 
 pub use base_incremental_value_store::BaseIncrementalValueStore;
 pub use incremental_executor::IncrementalExecutor;
@@ -11,3 +12,4 @@ pub use incremental_executors_initialiser::IncrementalExecutorsInitialiser;
 pub use incremental_data_aggregator::IncrementalDataAggregator;
 pub use incremental_data_purger::IncrementalDataPurger;
 pub use aggregation_runtime::AggregationRuntime;
+pub use aggregation_input_processor::AggregationInputProcessor;

--- a/siddhi_rust/src/core/partition/parser.rs
+++ b/siddhi_rust/src/core/partition/parser.rs
@@ -21,6 +21,7 @@ impl PartitionParser {
                 siddhi_app_context,
                 &builder.stream_junction_map,
                 &builder.table_definition_map,
+                &builder.aggregation_map,
             )?;
             let qr_arc = Arc::new(qr);
             builder.add_query_runtime(Arc::clone(&qr_arc));

--- a/siddhi_rust/src/core/query/output/insert_into_aggregation_processor.rs
+++ b/siddhi_rust/src/core/query/output/insert_into_aggregation_processor.rs
@@ -1,0 +1,40 @@
+use crate::core::config::siddhi_app_context::SiddhiAppContext;
+use crate::core::config::siddhi_query_context::SiddhiQueryContext;
+use crate::core::event::complex_event::ComplexEvent;
+use crate::core::event::stream::stream_event::StreamEvent;
+use crate::core::query::processor::{Processor, CommonProcessorMeta, ProcessingMode};
+use crate::core::aggregation::AggregationRuntime;
+use std::sync::{Arc, Mutex};
+
+#[derive(Debug)]
+pub struct InsertIntoAggregationProcessor {
+    meta: CommonProcessorMeta,
+    runtime: Arc<Mutex<AggregationRuntime>>,
+}
+
+impl InsertIntoAggregationProcessor {
+    pub fn new(runtime: Arc<Mutex<AggregationRuntime>>, app_ctx: Arc<SiddhiAppContext>, query_ctx: Arc<SiddhiQueryContext>) -> Self {
+        Self { meta: CommonProcessorMeta::new(app_ctx, query_ctx), runtime }
+    }
+}
+
+impl Processor for InsertIntoAggregationProcessor {
+    fn process(&self, mut chunk: Option<Box<dyn ComplexEvent>>) {
+        while let Some(mut event) = chunk {
+            let next = event.set_next(None);
+            if let Some(se) = event.as_any().downcast_ref::<StreamEvent>() {
+                self.runtime.lock().unwrap().process(se);
+            }
+            chunk = next;
+        }
+    }
+    fn next_processor(&self) -> Option<Arc<Mutex<dyn Processor>>> { None }
+    fn set_next_processor(&mut self, _next: Option<Arc<Mutex<dyn Processor>>>) {}
+    fn clone_processor(&self, qctx: &Arc<SiddhiQueryContext>) -> Box<dyn Processor> {
+        Box::new(Self::new(Arc::clone(&self.runtime), Arc::clone(&self.meta.siddhi_app_context), Arc::clone(qctx)))
+    }
+    fn get_siddhi_app_context(&self) -> Arc<SiddhiAppContext> { Arc::clone(&self.meta.siddhi_app_context) }
+    fn get_processing_mode(&self) -> ProcessingMode { ProcessingMode::DEFAULT }
+    fn is_stateful(&self) -> bool { true }
+}
+

--- a/siddhi_rust/src/core/query/output/mod.rs
+++ b/siddhi_rust/src/core/query/output/mod.rs
@@ -6,6 +6,7 @@
 
 pub mod insert_into_stream_processor;
 pub mod insert_into_table_processor;
+pub mod insert_into_aggregation_processor;
 pub mod update_table_processor;
 pub mod delete_table_processor;
 // pub mod update_or_insert_stream_processor; // For UPDATE OR INSERT
@@ -17,6 +18,7 @@ pub mod callback_processor; // Added
 
 pub use self::insert_into_stream_processor::InsertIntoStreamProcessor;
 pub use self::insert_into_table_processor::InsertIntoTableProcessor;
+pub use self::insert_into_aggregation_processor::InsertIntoAggregationProcessor;
 pub use self::update_table_processor::UpdateTableProcessor;
 pub use self::delete_table_processor::DeleteTableProcessor;
 pub use self::callback_processor::CallbackProcessor; // Added

--- a/siddhi_rust/tests/expression_parser_complex.rs
+++ b/siddhi_rust/tests/expression_parser_complex.rs
@@ -221,7 +221,7 @@ fn test_join_query_parsing() {
     junctions.insert("S2".to_string(), Arc::new(std::sync::Mutex::new(siddhi_rust::core::stream::stream_junction::StreamJunction::new("S2".to_string(), Arc::clone(&right_def), Arc::clone(&app_ctx), 1024, false, None))));
     junctions.insert("Out".to_string(), Arc::new(std::sync::Mutex::new(siddhi_rust::core::stream::stream_junction::StreamJunction::new("Out".to_string(), Arc::new(StreamDefinition::new("Out".to_string())), Arc::clone(&app_ctx), 1024, false, None))));
 
-    let res = QueryParser::parse_query(&query, &app_ctx, &junctions, &HashMap::new());
+    let res = QueryParser::parse_query(&query, &app_ctx, &junctions, &HashMap::new(), &HashMap::new());
     assert!(res.is_ok());
 
     // Also ensure expression parsing works standalone
@@ -267,7 +267,7 @@ fn test_pattern_query_parsing() {
     junctions.insert("B".to_string(), Arc::new(std::sync::Mutex::new(siddhi_rust::core::stream::stream_junction::StreamJunction::new("B".to_string(), Arc::clone(&b_def), Arc::clone(&app_ctx), 1024, false, None))));
     junctions.insert("Out".to_string(), Arc::new(std::sync::Mutex::new(siddhi_rust::core::stream::stream_junction::StreamJunction::new("Out".to_string(), Arc::new(StreamDefinition::new("Out".to_string())), Arc::clone(&app_ctx), 1024, false, None))));
 
-    let res = QueryParser::parse_query(&query, &app_ctx, &junctions, &HashMap::new());
+    let res = QueryParser::parse_query(&query, &app_ctx, &junctions, &HashMap::new(), &HashMap::new());
     assert!(res.is_ok());
 }
 
@@ -296,7 +296,7 @@ fn test_table_in_expression_query() {
     let mut table_defs = HashMap::new();
     table_defs.insert("T".to_string(), t_def);
 
-    let res = QueryParser::parse_query(&query, &app_ctx, &junctions, &table_defs);
+    let res = QueryParser::parse_query(&query, &app_ctx, &junctions, &table_defs, &HashMap::new());
     assert!(res.is_ok());
 }
 #[test]
@@ -311,7 +311,7 @@ fn test_join_query_parsing_from_string() {
     junctions.insert("S1".to_string(), Arc::new(Mutex::new(siddhi_rust::core::stream::stream_junction::StreamJunction::new("S1".to_string(), Arc::clone(&s1_def), Arc::clone(&app_ctx), 1024, false, None))));
     junctions.insert("S2".to_string(), Arc::new(Mutex::new(siddhi_rust::core::stream::stream_junction::StreamJunction::new("S2".to_string(), Arc::clone(&s2_def), Arc::clone(&app_ctx), 1024, false, None))));
     junctions.insert("Out".to_string(), Arc::new(Mutex::new(siddhi_rust::core::stream::stream_junction::StreamJunction::new("Out".to_string(), Arc::new(StreamDefinition::new("Out".to_string())), Arc::clone(&app_ctx), 1024, false, None))));
-    let res = QueryParser::parse_query(&query, &app_ctx, &junctions, &HashMap::new());
+    let res = QueryParser::parse_query(&query, &app_ctx, &junctions, &HashMap::new(), &HashMap::new());
     assert!(res.is_ok());
 }
 
@@ -327,6 +327,6 @@ fn test_pattern_query_parsing_from_string() {
     junctions.insert("A".to_string(), Arc::new(Mutex::new(siddhi_rust::core::stream::stream_junction::StreamJunction::new("A".to_string(), Arc::clone(&a_def), Arc::clone(&app_ctx), 1024, false, None))));
     junctions.insert("B".to_string(), Arc::new(Mutex::new(siddhi_rust::core::stream::stream_junction::StreamJunction::new("B".to_string(), Arc::clone(&b_def), Arc::clone(&app_ctx), 1024, false, None))));
     junctions.insert("Out".to_string(), Arc::new(Mutex::new(siddhi_rust::core::stream::stream_junction::StreamJunction::new("Out".to_string(), Arc::new(StreamDefinition::new("Out".to_string())), Arc::clone(&app_ctx), 1024, false, None))));
-    let res = QueryParser::parse_query(&query, &app_ctx, &junctions, &HashMap::new());
+    let res = QueryParser::parse_query(&query, &app_ctx, &junctions, &HashMap::new(), &HashMap::new());
     assert!(res.is_ok());
 }

--- a/siddhi_rust/tests/extensions.rs
+++ b/siddhi_rust/tests/extensions.rs
@@ -132,7 +132,7 @@ fn test_query_parser_uses_custom_window_factory() {
     let out_stream = OutputStream::new(OutputStreamAction::InsertInto(insert_action), None);
     let query = Query::query().from(input).select(selector).out_stream(out_stream);
 
-    let runtime = QueryParser::parse_query(&query, &app_ctx, &junctions, &HashMap::new()).unwrap();
+    let runtime = QueryParser::parse_query(&query, &app_ctx, &junctions, &HashMap::new(), &HashMap::new()).unwrap();
     let head = runtime.processor_chain_head.expect("head");
     let dbg = format!("{:?}", head.lock().unwrap());
     assert!(dbg.contains("DummyWindowProcessor"));

--- a/siddhi_rust/tests/join_queries.rs
+++ b/siddhi_rust/tests/join_queries.rs
@@ -68,14 +68,14 @@ fn build_join_query(join_type: JoinType) -> Query {
 fn test_parse_inner_join() {
     let (app_ctx, junctions) = setup_context();
     let q = build_join_query(JoinType::InnerJoin);
-    assert!(QueryParser::parse_query(&q, &app_ctx, &junctions, &HashMap::new()).is_ok());
+    assert!(QueryParser::parse_query(&q, &app_ctx, &junctions, &HashMap::new(), &HashMap::new()).is_ok());
 }
 
 #[test]
 fn test_parse_left_outer_join() {
     let (app_ctx, junctions) = setup_context();
     let q = build_join_query(JoinType::LeftOuterJoin);
-    assert!(QueryParser::parse_query(&q, &app_ctx, &junctions, &HashMap::new()).is_ok());
+    assert!(QueryParser::parse_query(&q, &app_ctx, &junctions, &HashMap::new(), &HashMap::new()).is_ok());
 }
 
 #[derive(Debug)]
@@ -116,7 +116,7 @@ fn collect_from_out_stream(
 fn test_inner_join_runtime() {
     let (app_ctx, junctions) = setup_context();
     let q = build_join_query(JoinType::InnerJoin);
-    assert!(QueryParser::parse_query(&q, &app_ctx, &junctions, &HashMap::new()).is_ok());
+    assert!(QueryParser::parse_query(&q, &app_ctx, &junctions, &HashMap::new(), &HashMap::new()).is_ok());
     let collected = collect_from_out_stream(&app_ctx, &junctions);
 
     {
@@ -136,7 +136,7 @@ fn test_inner_join_runtime() {
 fn test_left_outer_join_runtime() {
     let (app_ctx, junctions) = setup_context();
     let q = build_join_query(JoinType::LeftOuterJoin);
-    assert!(QueryParser::parse_query(&q, &app_ctx, &junctions, &HashMap::new()).is_ok());
+    assert!(QueryParser::parse_query(&q, &app_ctx, &junctions, &HashMap::new(), &HashMap::new()).is_ok());
     let collected = collect_from_out_stream(&app_ctx, &junctions);
 
     {

--- a/siddhi_rust/tests/pattern_queries.rs
+++ b/siddhi_rust/tests/pattern_queries.rs
@@ -61,6 +61,6 @@ fn build_sequence_query() -> Query {
 fn test_sequence_query_parse() {
     let (app_ctx, mut junctions) = setup_context();
     let q = build_sequence_query();
-    let res = QueryParser::parse_query(&q, &app_ctx, &mut junctions, &HashMap::new());
+    let res = QueryParser::parse_query(&q, &app_ctx, &mut junctions, &HashMap::new(), &HashMap::new());
     assert!(res.is_ok());
 }

--- a/siddhi_rust/tests/table_ops.rs
+++ b/siddhi_rust/tests/table_ops.rs
@@ -149,11 +149,11 @@ fn test_query_parser_with_table_actions() {
     table_defs.insert("T".to_string(), t_def);
 
     let q1 = parse_query("from S select val insert into table T").unwrap();
-    assert!(siddhi_rust::core::util::parser::QueryParser::parse_query(&q1, &app_ctx, &junctions, &table_defs).is_ok());
+    assert!(siddhi_rust::core::util::parser::QueryParser::parse_query(&q1, &app_ctx, &junctions, &table_defs, &HashMap::new()).is_ok());
 
     let q2 = parse_query("from S select val update table T").unwrap();
-    assert!(siddhi_rust::core::util::parser::QueryParser::parse_query(&q2, &app_ctx, &junctions, &table_defs).is_ok());
+    assert!(siddhi_rust::core::util::parser::QueryParser::parse_query(&q2, &app_ctx, &junctions, &table_defs, &HashMap::new()).is_ok());
 
     let q3 = parse_query("from S select val delete table T").unwrap();
-    assert!(siddhi_rust::core::util::parser::QueryParser::parse_query(&q3, &app_ctx, &junctions, &table_defs).is_ok());
+    assert!(siddhi_rust::core::util::parser::QueryParser::parse_query(&q3, &app_ctx, &junctions, &table_defs, &HashMap::new()).is_ok());
 }

--- a/siddhi_rust/tests/window_queries.rs
+++ b/siddhi_rust/tests/window_queries.rs
@@ -56,7 +56,7 @@ fn test_length_window_query_parse() {
     let out_stream = OutputStream::new(OutputStreamAction::InsertInto(insert_action), None);
     let query = Query::query().from(input).select(selector).out_stream(out_stream);
 
-    let res = QueryParser::parse_query(&query, &app_ctx, &junctions, &HashMap::new());
+    let res = QueryParser::parse_query(&query, &app_ctx, &junctions, &HashMap::new(), &HashMap::new());
     assert!(res.is_ok());
 }
 
@@ -71,7 +71,7 @@ fn test_time_window_query_parse() {
     let out_stream = OutputStream::new(OutputStreamAction::InsertInto(insert_action), None);
     let query = Query::query().from(input).select(selector).out_stream(out_stream);
 
-    let res = QueryParser::parse_query(&query, &app_ctx, &junctions, &HashMap::new());
+    let res = QueryParser::parse_query(&query, &app_ctx, &junctions, &HashMap::new(), &HashMap::new());
     assert!(res.is_ok());
 }
 


### PR DESCRIPTION
## Summary
- register default window processor factories during SiddhiContext init
- attach WindowRuntime processors using registered factories
- build AggregationRuntime instances and subscribe them to input streams
- allow queries to insert into aggregations
- adapt tests for new QueryParser signature

## Testing
- `cargo test --no-run`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684c0314431083258836238a5c46469a