### PR TITLE
Improve SiddhiAppRuntime lifecycle

### DIFF
--- a/siddhi_rust/src/core/partition/mod.rs
+++ b/siddhi_rust/src/core/partition/mod.rs
@@ -22,6 +22,12 @@ impl PartitionRuntime {
             println!("Starting query runtime {} in partition", qr.get_query_id());
         }
     }
+
+    pub fn shutdown(&self) {
+        for qr in &self.query_runtimes {
+            println!("Stopping query runtime {} in partition", qr.get_query_id());
+        }
+    }
 }
 
 pub mod parser;

--- a/siddhi_rust/src/core/siddhi_manager.rs
+++ b/siddhi_rust/src/core/siddhi_manager.rs
@@ -73,9 +73,10 @@ impl SiddhiManager {
         // SiddhiAppRuntime::new now handles creation of SiddhiAppContext and parsing
         let runtime = Arc::new(SiddhiAppRuntime::new(
             Arc::clone(&api_siddhi_app),
-            Arc::clone(&self.siddhi_context)
-            // siddhi_app_str_opt no longer passed here
+            Arc::clone(&self.siddhi_context),
+            siddhi_app_str_opt.clone(),
         )?);
+        runtime.start();
 
         self.siddhi_app_runtime_map.lock().expect("Mutex poisoned").insert(app_name.clone(), Arc::clone(&runtime)); // Use app_name for map key
         Ok(runtime)
@@ -186,7 +187,7 @@ impl SiddhiManager {
         let temp_runtime = SiddhiAppRuntime::new(
             Arc::clone(api_siddhi_app),
             Arc::clone(&self.siddhi_context)
-            // siddhi_app_str_opt no longer passed here
+            ,siddhi_app_str_opt
         )?;
         temp_runtime.start(); // This would internally build the plan, run initializations
         temp_runtime.shutdown(); // Clean up

--- a/siddhi_rust/src/core/util/scheduler.rs
+++ b/siddhi_rust/src/core/util/scheduler.rs
@@ -60,4 +60,8 @@ impl Scheduler {
         });
         Ok(())
     }
+
+    pub fn shutdown(&self) {
+        self.executor.wait_all();
+    }
 }

--- a/siddhi_rust/src/lib.rs
+++ b/siddhi_rust/src/lib.rs
@@ -134,7 +134,7 @@ mod tests {
         // c. Create SiddhiAppRuntime
         // SiddhiAppRuntime::new now takes Arc<ApiSiddhiApp> and Arc<SiddhiContext>
         println!("Test: Creating SiddhiAppRuntime...");
-        let runtime = SiddhiAppRuntime::new(runnable_api_app, siddhi_context)
+        let runtime = SiddhiAppRuntime::new(runnable_api_app, siddhi_context, None)
             .expect("Test: Failed to create SiddhiAppRuntime");
         println!("Test: SiddhiAppRuntime created successfully.");
 

--- a/siddhi_rust/tests/pattern_runtime.rs
+++ b/siddhi_rust/tests/pattern_runtime.rs
@@ -57,7 +57,7 @@ fn test_sequence_runtime_processing() {
     app.execution_element_list.push(ExecutionElement::Query(query));
 
     let app = Arc::new(app);
-    let runtime = SiddhiAppRuntime::new(Arc::clone(&app), siddhi_context).expect("runtime");
+    let runtime = SiddhiAppRuntime::new(Arc::clone(&app), siddhi_context, None).expect("runtime");
     let collected = Arc::new(Mutex::new(Vec::new()));
     runtime.add_callback("OutStream", Box::new(CollectCallback::new(Arc::clone(&collected)))).unwrap();
     runtime.start();
@@ -115,7 +115,7 @@ fn test_every_sequence() {
     app.execution_element_list.push(ExecutionElement::Query(query));
 
     let app = Arc::new(app);
-    let runtime = SiddhiAppRuntime::new(Arc::clone(&app), siddhi_context).expect("runtime");
+    let runtime = SiddhiAppRuntime::new(Arc::clone(&app), siddhi_context, None).expect("runtime");
     let collected = Arc::new(Mutex::new(Vec::new()));
     runtime.add_callback("OutStream", Box::new(CollectCallback::new(Arc::clone(&collected)))).unwrap();
     runtime.start();
@@ -173,7 +173,7 @@ fn test_logical_and_pattern() {
     app.execution_element_list.push(ExecutionElement::Query(query));
 
     let app = Arc::new(app);
-    let runtime = SiddhiAppRuntime::new(Arc::clone(&app), siddhi_context).expect("runtime");
+    let runtime = SiddhiAppRuntime::new(Arc::clone(&app), siddhi_context, None).expect("runtime");
     let collected = Arc::new(Mutex::new(Vec::new()));
     runtime.add_callback("OutStream", Box::new(CollectCallback::new(Arc::clone(&collected)))).unwrap();
     runtime.start();


### PR DESCRIPTION
## Summary
- propagate Siddhi app string when creating runtimes
- auto-start runtimes when created through SiddhiManager
- add shutdown handling for scheduler, partition runtimes and persistence
- expose scheduler shutdown
- adjust pattern runtime tests

## Testing
- `cargo test --lib --tests`

------
https://chatgpt.com/codex/tasks/task_e_684c191f17388325a22a9a966ef73758