### PR TITLE
Transfer builder maps to runtime

### DIFF
--- a/siddhi_rust/src/core/siddhi_app_runtime.rs
+++ b/siddhi_rust/src/core/siddhi_app_runtime.rs
@@ -12,7 +12,8 @@ use crate::core::stream::output::stream_callback::StreamCallback; // The trait
 use crate::core::query::query_runtime::QueryRuntime;
 use crate::core::partition::PartitionRuntime;
 use crate::core::util::parser::SiddhiAppParser; // For SiddhiAppParser::parse_siddhi_app_runtime_builder
-use crate::core::siddhi_app_runtime_builder::SiddhiAppRuntimeBuilder;
+use crate::core::siddhi_app_runtime_builder::{SiddhiAppRuntimeBuilder, TableRuntimePlaceholder};
+use crate::core::window::WindowRuntime;
 use crate::core::query::output::callback_processor::CallbackProcessor; // To be created
 use crate::core::query::processor::Processor; // Trait for CallbackProcessor
 use crate::core::persistence::SnapshotService;
@@ -33,11 +34,10 @@ pub struct SiddhiAppRuntime {
     pub query_runtimes: Vec<Arc<QueryRuntime>>,
     pub partition_runtimes: Vec<Arc<PartitionRuntime>>,
     pub scheduler: Option<Arc<crate::core::util::Scheduler>>,
+    pub table_map: HashMap<String, Arc<Mutex<TableRuntimePlaceholder>>>,
+    pub window_map: HashMap<String, Arc<Mutex<WindowRuntime>>>,
     pub aggregation_map: HashMap<String, Arc<Mutex<crate::core::aggregation::AggregationRuntime>>>,
-    // TODO: Add other runtime component maps (tables, windows, partitions, triggers)
-    // These would be moved from SiddhiAppRuntimeBuilder during the build() process.
-    // For now, using a placeholder to acknowledge they would exist.
-    pub _placeholder_table_map: HashMap<String, String>, // Example placeholder
+    // TODO: Add other runtime component maps (partitions, triggers)
 }
 
 impl SiddhiAppRuntime {

--- a/siddhi_rust/src/core/siddhi_app_runtime_builder.rs
+++ b/siddhi_rust/src/core/siddhi_app_runtime_builder.rs
@@ -106,12 +106,6 @@ impl SiddhiAppRuntimeBuilder {
             .get_scheduler()
             .unwrap_or_else(|| Arc::new(crate::core::util::Scheduler::new(Arc::new(crate::core::util::ExecutorService::default()))));
 
-        let mut aggregation_map = HashMap::new();
-        for (id, _def) in &self.aggregation_definition_map {
-            let runtime = AggregationRuntime::new(id.clone(), HashMap::new());
-            aggregation_map.insert(id.clone(), Arc::new(Mutex::new(runtime)));
-        }
-
         Ok(SiddhiAppRuntime {
             name: self.siddhi_app_context.name.clone(),
             siddhi_app: api_siddhi_app, // The original parsed API definition
@@ -121,16 +115,13 @@ impl SiddhiAppRuntimeBuilder {
             query_runtimes: self.query_runtimes,
             partition_runtimes: self.partition_runtimes,
             scheduler: Some(scheduler),
-            aggregation_map,
+            table_map: self.table_map,
+            window_map: self.window_map,
+            aggregation_map: self.aggregation_map,
             // Initialize other runtime fields (tables, windows, partitions, triggers)
             // These would typically be moved from the builder to the runtime instance.
-            // For now, they are not fields on SiddhiAppRuntime placeholder.
-            // tables: self.table_map,
-            // windows: self.window_map,
-            // aggregations: self.aggregation_map,
             // partitions: self.partition_runtimes,
             // triggers: self.trigger_runtimes,
-            _placeholder_table_map: HashMap::new(), // Placeholder field on SiddhiAppRuntime
         })
     }
 }


### PR DESCRIPTION
## Summary
- store table, window and aggregation maps on `SiddhiAppRuntime`
- pass those maps from `SiddhiAppRuntimeBuilder` directly
- adjust tests to use runtime aggregation map

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684c34278eec83259cadfd5b4513cc6c