### PR TITLE
Implement time constant parser

### DIFF
--- a/siddhi_rust/src/query_compiler/grammar.lalrpop
+++ b/siddhi_rust/src/query_compiler/grammar.lalrpop
@@ -11,6 +11,7 @@ use crate::query_api::execution::query::{Query, OnDemandQuery, StoreQuery, OnDem
 use crate::query_api::execution::query::selection::Selector;
 use crate::query_api::execution::query::selection::order_by_attribute::{OrderByAttribute, Order as OrderByOrder};
 use crate::query_api::expression::constant::Constant;
+use crate::query_api::expression::constant::TimeUtil;
 use crate::query_api::execution::query::output::output_stream::{
     OutputStream,
     OutputStreamAction,
@@ -563,4 +564,46 @@ STRING: String = {
 };
 
 NUMBER: i64 = { <r"[0-9]+"> => <>.parse().unwrap() };
+
+TimeUnit: String = {
+    "ms" => "ms".to_string(),
+    "millisec" => "millisec".to_string(),
+    "millisecs" => "millisecs".to_string(),
+    "millisecond" => "millisecond".to_string(),
+    "milliseconds" => "milliseconds".to_string(),
+    "sec" => "sec".to_string(),
+    "second" => "second".to_string(),
+    "seconds" => "seconds".to_string(),
+    "min" => "min".to_string(),
+    "minute" => "minute".to_string(),
+    "minutes" => "minutes".to_string(),
+    "h" => "h".to_string(),
+    "hour" => "hour".to_string(),
+    "hours" => "hours".to_string(),
+    "day" => "day".to_string(),
+    "days" => "days".to_string(),
+    "week" => "week".to_string(),
+    "weeks" => "weeks".to_string(),
+    "month" => "month".to_string(),
+    "months" => "months".to_string(),
+    "year" => "year".to_string(),
+    "years" => "years".to_string(),
+};
+
+pub TimeConstant: Constant = {
+    <n:NUMBER> <u:TimeUnit> => {
+        let millis = match u.as_str() {
+            "ms" | "millisec" | "millisecs" | "millisecond" | "milliseconds" => TimeUtil::millisec_val(n),
+            "sec" | "second" | "seconds" => TimeUtil::sec_val(n),
+            "min" | "minute" | "minutes" => TimeUtil::minute_val(n),
+            "h" | "hour" | "hours" => TimeUtil::hour_val(n),
+            "day" | "days" => TimeUtil::day_val(n),
+            "week" | "weeks" => TimeUtil::week_val(n),
+            "month" | "months" => TimeUtil::month_val(n),
+            "year" | "years" => TimeUtil::year_val(n),
+            _ => unreachable!(),
+        };
+        Constant::time(millis)
+    }
+};
 

--- a/siddhi_rust/src/query_compiler/siddhi_compiler.rs
+++ b/siddhi_rust/src/query_compiler/siddhi_compiler.rs
@@ -190,8 +190,10 @@ pub fn parse_function_definition(func_def_string: &str) -> Result<FunctionDefini
 // Java method returns io.siddhi.query.api.expression.constant.TimeConstant
 // Our ExpressionConstant is crate::query_api::expression::constant::Constant
 pub fn parse_time_constant(time_const_string: &str) -> Result<ExpressionConstant, String> {
-    let _ = update_variables(time_const_string)?;
-    Err("Time constant parsing not implemented".to_string())
+    let s = update_variables(time_const_string)?;
+    grammar::TimeConstantParser::new()
+        .parse(&s)
+        .map_err(|e| format!("{:?}", e))
 }
 
 pub fn parse_on_demand_query(query_string: &str) -> Result<OnDemandQuery, String> {

--- a/siddhi_rust/tests/time_constant.rs
+++ b/siddhi_rust/tests/time_constant.rs
@@ -1,0 +1,21 @@
+use siddhi_rust::query_compiler::parse_time_constant;
+use siddhi_rust::query_api::expression::constant::TimeUtil;
+
+#[test]
+fn test_parse_seconds() {
+    let c = parse_time_constant("5 sec").unwrap();
+    assert_eq!(c, TimeUtil::sec(5));
+}
+
+#[test]
+fn test_parse_minutes() {
+    let c = parse_time_constant("2 min").unwrap();
+    assert_eq!(c, TimeUtil::minute(2));
+}
+
+#[test]
+fn test_parse_hours() {
+    let c = parse_time_constant("1 hour").unwrap();
+    assert_eq!(c, TimeUtil::hour(1));
+}
+


### PR DESCRIPTION
## Summary
- support converting strings like `"5 sec"` into `ExpressionConstant::Time`
- verify parsing seconds, minutes and hours
- parse time constants using lalrpop grammar

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684ccaff2938832588a1ab953b0ca48c