### PR TITLE
Implement trigger runtime and parsing

### DIFF
--- a/siddhi_rust/src/core/siddhi_app_runtime_builder.rs
+++ b/siddhi_rust/src/core/siddhi_app_runtime_builder.rs
@@ -14,7 +14,7 @@ use std::sync::{Arc, Mutex};
 
 // Placeholders for runtime components until they are defined
 #[derive(Debug, Clone, Default)] pub struct TableRuntimePlaceholder {}
-#[derive(Debug, Clone, Default)] pub struct TriggerRuntimePlaceholder {}
+use crate::core::trigger::TriggerRuntime;
 
 
 #[derive(Debug)]
@@ -33,7 +33,7 @@ pub struct SiddhiAppRuntimeBuilder {
 
     pub query_runtimes: Vec<Arc<QueryRuntime>>,
     pub partition_runtimes: Vec<Arc<PartitionRuntime>>,
-    pub trigger_runtimes: Vec<Arc<TriggerRuntimePlaceholder>>,
+    pub trigger_runtimes: Vec<Arc<TriggerRuntime>>,
 }
 
 impl SiddhiAppRuntimeBuilder {
@@ -88,7 +88,7 @@ impl SiddhiAppRuntimeBuilder {
     pub fn add_partition_runtime(&mut self, partition_runtime: Arc<PartitionRuntime>) {
         self.partition_runtimes.push(partition_runtime);
     }
-    pub fn add_trigger_runtime(&mut self, trigger_runtime: Arc<TriggerRuntimePlaceholder>) {
+    pub fn add_trigger_runtime(&mut self, trigger_runtime: Arc<TriggerRuntime>) {
         self.trigger_runtimes.push(trigger_runtime);
     }
 
@@ -118,10 +118,7 @@ impl SiddhiAppRuntimeBuilder {
             table_map: self.table_map,
             window_map: self.window_map,
             aggregation_map: self.aggregation_map,
-            // Initialize other runtime fields (tables, windows, partitions, triggers)
-            // These would typically be moved from the builder to the runtime instance.
-            // partitions: self.partition_runtimes,
-            // triggers: self.trigger_runtimes,
+            trigger_runtimes: self.trigger_runtimes,
         })
     }
 }

--- a/siddhi_rust/src/core/trigger/mod.rs
+++ b/siddhi_rust/src/core/trigger/mod.rs
@@ -1,0 +1,7 @@
+// siddhi_rust/src/core/trigger/mod.rs
+
+//! Basic trigger runtime implementation.
+
+pub mod trigger_runtime;
+
+pub use trigger_runtime::TriggerRuntime;

--- a/siddhi_rust/src/core/trigger/trigger_runtime.rs
+++ b/siddhi_rust/src/core/trigger/trigger_runtime.rs
@@ -1,0 +1,56 @@
+// siddhi_rust/src/core/trigger/trigger_runtime.rs
+
+use crate::query_api::definition::TriggerDefinition;
+use crate::core::stream::stream_junction::StreamJunction;
+use crate::core::event::event::Event;
+use crate::core::event::value::AttributeValue;
+use crate::core::util::scheduler::{Scheduler, Schedulable};
+use std::sync::{Arc, Mutex};
+
+#[derive(Debug)]
+pub struct TriggerRuntime {
+    pub definition: Arc<TriggerDefinition>,
+    pub stream_junction: Arc<Mutex<StreamJunction>>, 
+    scheduler: Arc<Scheduler>,
+}
+
+impl TriggerRuntime {
+    pub fn new(
+        definition: Arc<TriggerDefinition>,
+        stream_junction: Arc<Mutex<StreamJunction>>, 
+        scheduler: Arc<Scheduler>,
+    ) -> Self {
+        Self { definition, stream_junction, scheduler }
+    }
+
+    pub fn start(&self) {
+        let task = Arc::new(TriggerTask {
+            junction: Arc::clone(&self.stream_junction),
+        });
+        if let Some(period) = self.definition.at_every {
+            self.scheduler.schedule_periodic(period, task, None);
+        } else if let Some(at) = &self.definition.at {
+            if at.trim().eq_ignore_ascii_case("start") {
+                // Emit immediately
+                let now = chrono::Utc::now().timestamp_millis();
+                TriggerTask { junction: Arc::clone(&self.stream_junction) }.on_time(now);
+            } else {
+                let _ = self.scheduler.schedule_cron(at, task, None);
+            }
+        }
+    }
+
+    pub fn shutdown(&self) {}
+}
+
+#[derive(Debug)]
+struct TriggerTask {
+    junction: Arc<Mutex<StreamJunction>>, 
+}
+
+impl Schedulable for TriggerTask {
+    fn on_time(&self, timestamp: i64) {
+        let ev = Event::new_with_data(timestamp, vec![AttributeValue::Long(timestamp)]);
+        self.junction.lock().unwrap().send_event(ev);
+    }
+}

--- a/siddhi_rust/src/core/util/parser/mod.rs
+++ b/siddhi_rust/src/core/util/parser/mod.rs
@@ -3,6 +3,7 @@
 pub mod expression_parser;
 pub mod query_parser; // Added
 pub mod siddhi_app_parser; // Added
+pub mod trigger_parser;
 // Other parsers will be added here later:
 // pub mod aggregation_parser;
 // ... etc.
@@ -10,4 +11,5 @@ pub mod siddhi_app_parser; // Added
 pub use self::expression_parser::{parse_expression, ExpressionParserContext};
 pub use self::query_parser::QueryParser; // Added
 pub use self::siddhi_app_parser::SiddhiAppParser; // Added
+pub use self::trigger_parser::TriggerParser;
 pub use crate::core::partition::parser::PartitionParser;

--- a/siddhi_rust/src/core/util/parser/siddhi_app_parser.rs
+++ b/siddhi_rust/src/core/util/parser/siddhi_app_parser.rs
@@ -21,6 +21,7 @@ use crate::core::partition::parser::PartitionParser;
 // use super::definition_parser_helpers::*; // For defineStreamDefinitions, defineTableDefinitions etc.
 use crate::core::util::SiddhiConstants as CoreSiddhiConstants; // Core constants, if any, vs query_api constants
 use super::query_parser::QueryParser; // Use the real QueryParser implementation
+use super::trigger_parser::TriggerParser;
 
 pub struct SiddhiAppParser;
 
@@ -230,7 +231,10 @@ impl SiddhiAppParser {
             }
         }
 
-        // TODO: Define Triggers
+        for (_id, trig_def) in &api_siddhi_app.trigger_definition_map {
+            let runtime = TriggerParser::parse(&mut builder, trig_def, &siddhi_app_context)?;
+            builder.add_trigger_runtime(Arc::new(runtime));
+        }
 
         Ok(builder)
     }

--- a/siddhi_rust/src/core/util/parser/trigger_parser.rs
+++ b/siddhi_rust/src/core/util/parser/trigger_parser.rs
@@ -1,0 +1,42 @@
+// siddhi_rust/src/core/util/parser/trigger_parser.rs
+
+use std::sync::{Arc, Mutex};
+
+use crate::core::config::siddhi_app_context::SiddhiAppContext;
+use crate::core::stream::stream_junction::StreamJunction;
+use crate::core::trigger::TriggerRuntime;
+use crate::core::siddhi_app_runtime_builder::SiddhiAppRuntimeBuilder;
+use crate::query_api::definition::{StreamDefinition, AttributeType, TriggerDefinition};
+use crate::query_api::constants::TRIGGERED_TIME;
+
+pub struct TriggerParser;
+
+impl TriggerParser {
+    pub fn parse(
+        builder: &mut SiddhiAppRuntimeBuilder,
+        definition: &TriggerDefinition,
+        siddhi_app_context: &Arc<SiddhiAppContext>,
+    ) -> Result<TriggerRuntime, String> {
+        let stream_def = Arc::new(StreamDefinition::new(definition.id.clone())
+            .attribute(TRIGGERED_TIME.to_string(), AttributeType::LONG));
+        builder.add_stream_definition(Arc::clone(&stream_def));
+        let junction = Arc::new(Mutex::new(StreamJunction::new(
+            definition.id.clone(),
+            Arc::clone(&stream_def),
+            Arc::clone(siddhi_app_context),
+            siddhi_app_context.buffer_size as usize,
+            false,
+            None,
+        )));
+        builder.add_stream_junction(definition.id.clone(), Arc::clone(&junction));
+
+        let scheduler = siddhi_app_context
+            .get_scheduler()
+            .unwrap_or_else(|| Arc::new(crate::core::util::Scheduler::new(Arc::new(crate::core::util::ExecutorService::default()))));
+        Ok(TriggerRuntime::new(
+            Arc::new(definition.clone()),
+            junction,
+            scheduler,
+        ))
+    }
+}

--- a/siddhi_rust/tests/app_runner_triggers.rs
+++ b/siddhi_rust/tests/app_runner_triggers.rs
@@ -1,0 +1,30 @@
+#[path = "common/mod.rs"]
+mod common;
+use common::AppRunner;
+use siddhi_rust::query_api::siddhi_app::SiddhiApp;
+use siddhi_rust::query_api::definition::TriggerDefinition;
+use siddhi_rust::query_api::expression::constant::TimeUtil;
+use std::time::Duration;
+use std::thread::sleep;
+
+#[test]
+fn start_trigger_emits_once() {
+    let mut app = SiddhiApp::new("T1".to_string());
+    app.add_trigger_definition(TriggerDefinition::id("TrigStream".to_string()).at("start".to_string()));
+    let runner = AppRunner::new_from_api(app, "TrigStream");
+    sleep(Duration::from_millis(50));
+    let out = runner.shutdown();
+    assert_eq!(out.len(), 1);
+}
+
+#[test]
+fn periodic_trigger_emits() {
+    let mut app = SiddhiApp::new("T2".to_string());
+    let trig = TriggerDefinition::id("PTStream".to_string())
+        .at_every_time_constant(TimeUtil::millisec(50)).unwrap();
+    app.add_trigger_definition(trig);
+    let runner = AppRunner::new_from_api(app, "PTStream");
+    sleep(Duration::from_millis(130));
+    let out = runner.shutdown();
+    assert!(out.len() >= 2);
+}


### PR DESCRIPTION
## Summary
- add trigger runtime using scheduler
- parse TriggerDefinitions into runtimes
- extend builder/runtime to manage triggers
- add integration tests for triggers

## Testing
- `cargo test --no-run`
- `cargo test --test app_runner_triggers -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_684cce44789083258979b2400ef0ca34