### PR TITLE
Add Siddhi runner CLI

### DIFF
--- a/siddhi_rust/README.md
+++ b/siddhi_rust/README.md
@@ -130,6 +130,17 @@ let cmp = CompareExpressionExecutor::new(
 assert_eq!(cmp.execute(None), Some(AttributeValue::Bool(true)));
 ```
 
+### CLI Runner
+
+A small binary `run_siddhi` can execute a SiddhiQL file and log emitted events.
+Build and run with:
+
+```bash
+cargo run --bin run_siddhi examples/sample.siddhi
+```
+
+All streams have a `LogSink` attached so events appear on stdout.
+
 ## Next Planned Phases (High-Level)
 
 1.  **Stabilize Phase 1**: Make the `test_simple_filter_projection_query` compile and run successfully by fully implementing the simplified logic paths in `ExpressionParser`, `VariableExpressionExecutor`, `FilterProcessor`, `SelectProcessor`, and event data handling.

--- a/siddhi_rust/examples/run_sample.sh
+++ b/siddhi_rust/examples/run_sample.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Run the example Siddhi app with the CLI
+cargo run --bin run_siddhi examples/sample.siddhi

--- a/siddhi_rust/examples/sample.siddhi
+++ b/siddhi_rust/examples/sample.siddhi
@@ -1,0 +1,4 @@
+define stream InStream (a int);
+define stream OutStream (a int);
+from InStream select a insert into OutStream;
+

--- a/siddhi_rust/src/bin/run_siddhi.rs
+++ b/siddhi_rust/src/bin/run_siddhi.rs
@@ -1,0 +1,47 @@
+use std::env;
+use std::fs;
+use std::thread;
+use std::time::Duration;
+
+use siddhi_rust::core::siddhi_manager::SiddhiManager;
+use siddhi_rust::core::stream::output::sink::LogSink;
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 2 {
+        eprintln!("Usage: {} <siddhi_file>", args[0]);
+        std::process::exit(1);
+    }
+
+    let file = &args[1];
+    let content = match fs::read_to_string(file) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("Failed to read {}: {}", file, e);
+            std::process::exit(1);
+        }
+    };
+
+    let manager = SiddhiManager::new();
+    let runtime = match manager.create_siddhi_app_runtime_from_string(&content) {
+        Ok(rt) => rt,
+        Err(e) => {
+            eprintln!("Failed to create runtime: {}", e);
+            std::process::exit(1);
+        }
+    };
+
+    for stream_id in runtime.stream_junction_map.keys() {
+        let _ = runtime.add_callback(stream_id, Box::new(LogSink::new()));
+    }
+
+    println!(
+        "Running Siddhi app '{}'. Press Ctrl+C to exit",
+        runtime.name
+    );
+
+    // Keep the main thread alive until interrupted.
+    loop {
+        thread::sleep(Duration::from_secs(1));
+    }
+}


### PR DESCRIPTION
## Summary
- add `run_siddhi` binary that executes a SiddhiQL file
- document the new CLI in the crate README
- add sample SiddhiQL file and helper script under `examples/`

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684ce0e939cc832580029842da0f9295