### PR TITLE
Apply rustfmt and reduce clippy warnings

### DIFF
--- a/siddhi_rust/README.md
+++ b/siddhi_rust/README.md
@@ -168,3 +168,4 @@ After parsing, `AggregationRuntime` instances are created when building a
 `SiddhiAppRuntime`. Events fed to the runtime will update the aggregation buckets
 for each configured duration.  Query APIs for reading these buckets are not yet
 implemented, but tests demonstrate the accumulation logic.
+\nNote: The project still emits numerous compiler warnings due to incomplete features and placeholder code. These are expected during the early porting phase.

--- a/siddhi_rust/src/core/config/siddhi_query_context.rs
+++ b/siddhi_rust/src/core/config/siddhi_query_context.rs
@@ -72,7 +72,7 @@ impl SiddhiQueryContext {
     }
 
     pub fn get_output_event_type(&self) -> Option<OutputEventType> {
-        self.output_event_type.clone()
+        self.output_event_type
     }
 
     pub fn set_output_event_type(&mut self, output_event_type: OutputEventType) {

--- a/siddhi_rust/src/core/event/stream/meta_stream_event.rs
+++ b/siddhi_rust/src/core/event/stream/meta_stream_event.rs
@@ -52,10 +52,7 @@ impl MetaStreamEvent {
             .enumerate()
         {
             // Assuming get_name() and get_type() are available on ApiAttribute
-            attribute_info.insert(
-                api_attr.name.clone(),
-                (index, api_attr.attribute_type.clone()),
-            );
+            attribute_info.insert(api_attr.name.clone(), (index, api_attr.attribute_type));
         }
         Self {
             input_stream_definition: input_stream_def.clone(),
@@ -88,7 +85,7 @@ impl MetaStreamEvent {
         self.attribute_info = self
             .attribute_info
             .iter()
-            .map(|(k, (idx, t))| (k.clone(), (idx + offset, t.clone())))
+            .map(|(k, (idx, t))| (k.clone(), (idx + offset, *t)))
             .collect();
     }
 
@@ -146,7 +143,7 @@ impl MetaStreamEvent {
             .abstract_definition
             .attribute_list
             .iter()
-            .map(|attr| (attr.name.clone(), attr.attribute_type.clone()))
+            .map(|attr| (attr.name.clone(), attr.attribute_type))
             .collect()
     }
 

--- a/siddhi_rust/src/core/event/value.rs
+++ b/siddhi_rust/src/core/event/value.rs
@@ -7,6 +7,7 @@ use std::fmt;
 // query_api::definition::attribute::Type enum has STRING, INT, LONG, FLOAT, DOUBLE, BOOL, OBJECT.
 // This enum should reflect those types for data carrying.
 
+#[derive(Default)]
 pub enum AttributeValue {
     String(String),
     Int(i32),
@@ -15,7 +16,8 @@ pub enum AttributeValue {
     Double(f64),
     Bool(bool),
     Object(Option<Box<dyn Any + Send + Sync>>), // For OBJECT type, ensure thread safety
-    Null,                                       // To represent null values explicitly
+    #[default]
+    Null,                         // To represent null values explicitly
 }
 
 // Manual implementation of Debug to handle Box<dyn Any>
@@ -67,12 +69,6 @@ impl Clone for AttributeValue {
             AttributeValue::Object(_) => AttributeValue::Object(None),
             AttributeValue::Null => AttributeValue::Null,
         }
-    }
-}
-
-impl Default for AttributeValue {
-    fn default() -> Self {
-        AttributeValue::Null
     }
 }
 

--- a/siddhi_rust/src/core/executor/math/add.rs
+++ b/siddhi_rust/src/core/executor/math/add.rs
@@ -36,12 +36,6 @@ impl AddExpressionExecutor {
             (ApiAttributeType::FLOAT, _) | (_, ApiAttributeType::FLOAT) => ApiAttributeType::FLOAT,
             (ApiAttributeType::LONG, _) | (_, ApiAttributeType::LONG) => ApiAttributeType::LONG,
             (ApiAttributeType::INT, _) | (_, ApiAttributeType::INT) => ApiAttributeType::INT,
-            _ => {
-                return Err(format!(
-                    "Addition not supported for incompatible types: {:?} and {:?}",
-                    left_type, right_type
-                ))
-            }
         };
         Ok(Self {
             left_executor: left,

--- a/siddhi_rust/src/core/executor/math/common.rs
+++ b/siddhi_rust/src/core/executor/math/common.rs
@@ -11,7 +11,7 @@ pub(super) trait CoerceNumeric {
 }
 
 impl CoerceNumeric for AttributeValue {
-    fn to_i32_or_err_str(&self, op_name: &str) -> Option<i32> {
+    fn to_i32_or_err_str(&self, _op_name: &str) -> Option<i32> {
         match self {
             AttributeValue::Int(v) => Some(*v),
             AttributeValue::Long(v) => Some(*v as i32),
@@ -23,7 +23,7 @@ impl CoerceNumeric for AttributeValue {
             }
         }
     }
-    fn to_i64_or_err_str(&self, op_name: &str) -> Option<i64> {
+    fn to_i64_or_err_str(&self, _op_name: &str) -> Option<i64> {
         match self {
             AttributeValue::Int(v) => Some(*v as i64),
             AttributeValue::Long(v) => Some(*v),
@@ -32,7 +32,7 @@ impl CoerceNumeric for AttributeValue {
             _ => None,
         }
     }
-    fn to_f32_or_err_str(&self, op_name: &str) -> Option<f32> {
+    fn to_f32_or_err_str(&self, _op_name: &str) -> Option<f32> {
         match self {
             AttributeValue::Int(v) => Some(*v as f32),
             AttributeValue::Long(v) => Some(*v as f32),
@@ -41,7 +41,7 @@ impl CoerceNumeric for AttributeValue {
             _ => None,
         }
     }
-    fn to_f64_or_err_str(&self, op_name: &str) -> Option<f64> {
+    fn to_f64_or_err_str(&self, _op_name: &str) -> Option<f64> {
         match self {
             AttributeValue::Int(v) => Some(*v as f64),
             AttributeValue::Long(v) => Some(*v as f64),

--- a/siddhi_rust/src/core/executor/math/mod_expression_executor.rs
+++ b/siddhi_rust/src/core/executor/math/mod_expression_executor.rs
@@ -40,12 +40,6 @@ impl ModExpressionExecutor {
             (ApiAttributeType::FLOAT, _) | (_, ApiAttributeType::FLOAT) => ApiAttributeType::FLOAT,
             (ApiAttributeType::LONG, _) | (_, ApiAttributeType::LONG) => ApiAttributeType::LONG,
             (ApiAttributeType::INT, _) | (_, ApiAttributeType::INT) => ApiAttributeType::INT, // Base case
-            _ => {
-                return Err(format!(
-                    "Modulo not supported for incompatible types: {:?} and {:?}",
-                    left_type, right_type
-                ))
-            }
         };
         Ok(Self {
             left_executor: left,

--- a/siddhi_rust/src/core/executor/math/multiply.rs
+++ b/siddhi_rust/src/core/executor/math/multiply.rs
@@ -40,12 +40,6 @@ impl MultiplyExpressionExecutor {
             (ApiAttributeType::FLOAT, _) | (_, ApiAttributeType::FLOAT) => ApiAttributeType::FLOAT,
             (ApiAttributeType::LONG, _) | (_, ApiAttributeType::LONG) => ApiAttributeType::LONG,
             (ApiAttributeType::INT, _) | (_, ApiAttributeType::INT) => ApiAttributeType::INT,
-            _ => {
-                return Err(format!(
-                    "Multiplication not supported for incompatible types: {:?} and {:?}",
-                    left_type, right_type
-                ))
-            }
         };
         Ok(Self {
             left_executor: left,

--- a/siddhi_rust/src/core/executor/math/subtract.rs
+++ b/siddhi_rust/src/core/executor/math/subtract.rs
@@ -38,12 +38,6 @@ impl SubtractExpressionExecutor {
             (ApiAttributeType::FLOAT, _) | (_, ApiAttributeType::FLOAT) => ApiAttributeType::FLOAT,
             (ApiAttributeType::LONG, _) | (_, ApiAttributeType::LONG) => ApiAttributeType::LONG,
             (ApiAttributeType::INT, _) | (_, ApiAttributeType::INT) => ApiAttributeType::INT,
-            _ => {
-                return Err(format!(
-                    "Subtraction not supported for incompatible types: {:?} and {:?}",
-                    left_type, right_type
-                ))
-            }
         };
         Ok(Self {
             left_executor: left,

--- a/siddhi_rust/src/core/siddhi_app_runtime.rs
+++ b/siddhi_rust/src/core/siddhi_app_runtime.rs
@@ -6,9 +6,8 @@ use crate::core::config::siddhi_query_context::SiddhiQueryContext; // For add_ca
 use crate::core::partition::PartitionRuntime;
 use crate::core::persistence::SnapshotService;
 use crate::core::query::output::callback_processor::CallbackProcessor; // To be created
-use crate::core::query::processor::Processor; // Trait for CallbackProcessor
 use crate::core::query::query_runtime::QueryRuntime;
-use crate::core::siddhi_app_runtime_builder::{SiddhiAppRuntimeBuilder, TableRuntimePlaceholder};
+use crate::core::siddhi_app_runtime_builder::TableRuntimePlaceholder;
 use crate::core::stream::input::input_handler::InputHandler;
 use crate::core::stream::input::input_manager::InputManager;
 use crate::core::stream::output::stream_callback::StreamCallback; // The trait
@@ -174,7 +173,7 @@ impl SiddhiAppRuntime {
     }
 
     pub fn start(&self) {
-        if let Some(scheduler) = &self.scheduler {
+        if self.scheduler.is_some() {
             // placeholder: scheduler is kept alive by self
             println!("Scheduler initialized for SiddhiAppRuntime '{}'", self.name);
         }

--- a/siddhi_rust/src/core/siddhi_manager.rs
+++ b/siddhi_rust/src/core/siddhi_manager.rs
@@ -10,9 +10,7 @@ use crate::core::executor::ScalarFunctionExecutor; // Added for UDFs
 use crate::core::DataSource;
 use crate::query_compiler::parse as parse_siddhi_ql_string_to_api_app; // Added for data sources
                                                                        // Placeholder for actual persistence store trait/type
-use crate::core::config::siddhi_context::{
-    ConfigManagerPlaceholder, DataSourcePlaceholder, ExtensionClassPlaceholder,
-};
+use crate::core::config::siddhi_context::{ConfigManagerPlaceholder, ExtensionClassPlaceholder};
 use crate::core::persistence::{IncrementalPersistenceStore, PersistenceStore};
 
 use std::collections::HashMap;

--- a/siddhi_rust/src/query_api/execution/query/output/output_stream.rs
+++ b/siddhi_rust/src/query_api/execution/query/output/output_stream.rs
@@ -2,19 +2,14 @@ use super::stream::{SetAttribute, UpdateSet};
 use crate::query_api::expression::Expression;
 use crate::query_api::siddhi_element::SiddhiElement; // Using UpdateSet
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Copy)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Copy, Default)]
 pub enum OutputEventType {
     ExpiredEvents,
+    #[default]
     CurrentEvents,
     AllEvents,
     AllRawEvents,
     ExpiredRawEvents,
-}
-
-impl Default for OutputEventType {
-    fn default() -> Self {
-        OutputEventType::CurrentEvents
-    }
 }
 
 // Action Structs: These do not compose SiddhiElement directly.

--- a/siddhi_rust/src/query_api/execution/query/output/ratelimit/output_rate.rs
+++ b/siddhi_rust/src/query_api/execution/query/output/ratelimit/output_rate.rs
@@ -4,17 +4,12 @@ use super::time_output_rate::TimeOutputRate;
 use crate::query_api::expression::constant::{Constant, ConstantValueWithFloat as ConstantValue};
 use crate::query_api::siddhi_element::SiddhiElement; // Use renamed ConstantValue
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Copy)] // Added Eq, Hash, Copy
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Copy, Default)] // Added Eq, Hash, Copy
 pub enum OutputRateBehavior {
+    #[default]
     All,
     First,
     Last,
-}
-
-impl Default for OutputRateBehavior {
-    fn default() -> Self {
-        OutputRateBehavior::All
-    }
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/siddhi_rust/src/query_api/expression/condition/compare.rs
+++ b/siddhi_rust/src/query_api/expression/condition/compare.rs
@@ -2,20 +2,15 @@
 use crate::query_api::expression::Expression;
 use crate::query_api::siddhi_element::SiddhiElement;
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Copy)] // Added Eq, Hash, Copy
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Copy, Default)] // Added Eq, Hash, Copy
 pub enum Operator {
     LessThan,
     GreaterThan,
     LessThanEqual,
     GreaterThanEqual,
+    #[default]
     Equal,
     NotEqual,
-}
-
-impl Default for Operator {
-    fn default() -> Self {
-        Operator::Equal
-    } // Defaulting to Equal, could be any.
 }
 
 // This From impl was for a placeholder Java enum, can be removed or adapted if JNI is used.

--- a/siddhi_rust/src/query_api/siddhi_element.rs
+++ b/siddhi_rust/src/query_api/siddhi_element.rs
@@ -1,6 +1,6 @@
 // Corresponds to io.siddhi.query.api.SiddhiElement
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)] // Added Eq, Hash
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Default)] // Added Eq, Hash, Default
 pub struct SiddhiElement {
     pub query_context_start_index: Option<(i32, i32)>,
     pub query_context_end_index: Option<(i32, i32)>,
@@ -11,15 +11,6 @@ impl SiddhiElement {
         SiddhiElement {
             query_context_start_index: start_index,
             query_context_end_index: end_index,
-        }
-    }
-}
-
-impl Default for SiddhiElement {
-    fn default() -> Self {
-        SiddhiElement {
-            query_context_start_index: None,
-            query_context_end_index: None,
         }
     }
 }


### PR DESCRIPTION
## Summary
- clean up unused imports and unreachable patterns
- derive `Default` for several enums and structs
- fix minor clippy issues
- note remaining warnings in README

## Testing
- `cargo clippy --all-targets`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684d2d4f64d48325bfdc7f2d75fd3933