### PR TITLE
Add cron trigger support test

### DIFF
--- a/siddhi_rust/src/query_compiler/grammar.lalrpop
+++ b/siddhi_rust/src/query_compiler/grammar.lalrpop
@@ -3,7 +3,14 @@
 
 grammar;
 
-use crate::query_api::definition::{StreamDefinition, TableDefinition, AggregationDefinition, WindowDefinition, FunctionDefinition};
+use crate::query_api::definition::{
+    StreamDefinition,
+    TableDefinition,
+    AggregationDefinition,
+    WindowDefinition,
+    FunctionDefinition,
+    TriggerDefinition,
+};
 use crate::query_api::definition::attribute::Type as AttributeType;
 use crate::query_api::definition::attribute::Attribute;
 use crate::query_api::execution::query::input::handler::WindowHandler;
@@ -115,6 +122,15 @@ pub WindowDef: WindowDefinition = {
 pub FunctionDef: FunctionDefinition = {
     "define" "function" <id:Ident> "[" <lang:Ident> "]" "return" <ty:Type> <body:STRING> => {
         FunctionDefinition::new(id, lang, body, ty)
+    }
+};
+
+pub TriggerDef: TriggerDefinition = {
+    "define" "trigger" <id:Ident> "at" "every" <dur:TimeConstant> => {
+        TriggerDefinition::id(id).at_every_time_constant(dur).unwrap()
+    },
+    "define" "trigger" <id:Ident> "at" <expr:STRING> => {
+        TriggerDefinition::id(id).at(expr)
     }
 };
 

--- a/siddhi_rust/src/query_compiler/mod.rs
+++ b/siddhi_rust/src/query_compiler/mod.rs
@@ -13,6 +13,7 @@ pub use self::siddhi_compiler::{
     parse_store_query,
     parse_stream_definition,
     parse_table_definition,
+    parse_trigger_definition,
     parse_time_constant,
     parse_window_definition,
     update_variables, // if this is also intended to be part of the public API

--- a/siddhi_rust/src/query_compiler/siddhi_compiler.rs
+++ b/siddhi_rust/src/query_compiler/siddhi_compiler.rs
@@ -2,8 +2,13 @@
 // Ensure these paths are correct based on query_api module structure and re-exports.
 use crate::query_api::{
     definition::{
-        attribute::Type as AttributeType, AggregationDefinition, FunctionDefinition,
-        StreamDefinition, TableDefinition, WindowDefinition,
+        attribute::Type as AttributeType,
+        AggregationDefinition,
+        FunctionDefinition,
+        StreamDefinition,
+        TableDefinition,
+        TriggerDefinition,
+        WindowDefinition,
     },
     execution::{
         query::{
@@ -141,6 +146,9 @@ pub fn parse(siddhi_app_string: &str) -> Result<SiddhiApp, String> {
         } else if lower.starts_with("define function") {
             let def = parse_function_definition(&stmt)?;
             app.add_function_definition(def);
+        } else if lower.starts_with("define trigger") {
+            let def = parse_trigger_definition(&stmt)?;
+            app.add_trigger_definition(def);
         } else if lower.starts_with("define aggregation") {
             let def = parse_aggregation_definition(&stmt)?;
             app.add_aggregation_definition(def);
@@ -198,6 +206,13 @@ pub fn parse_query(query_string: &str) -> Result<Query, String> {
 pub fn parse_function_definition(func_def_string: &str) -> Result<FunctionDefinition, String> {
     let s = update_variables(func_def_string)?;
     grammar::FunctionDefParser::new()
+        .parse(&s)
+        .map_err(|e| format!("{:?}", e))
+}
+
+pub fn parse_trigger_definition(trig_def_string: &str) -> Result<TriggerDefinition, String> {
+    let s = update_variables(trig_def_string)?;
+    grammar::TriggerDefParser::new()
         .parse(&s)
         .map_err(|e| format!("{:?}", e))
 }

--- a/siddhi_rust/tests/app_runner_triggers.rs
+++ b/siddhi_rust/tests/app_runner_triggers.rs
@@ -31,3 +31,15 @@ fn periodic_trigger_emits() {
     let out = runner.shutdown();
     assert!(out.len() >= 2);
 }
+
+#[test]
+fn cron_trigger_emits() {
+    let mut app = SiddhiApp::new("T3".to_string());
+    app.add_trigger_definition(
+        TriggerDefinition::id("CronStream".to_string()).at("*/1 * * * * *".to_string()),
+    );
+    let runner = AppRunner::new_from_api(app, "CronStream");
+    sleep(Duration::from_millis(2200));
+    let out = runner.shutdown();
+    assert!(out.len() >= 2);
+}

--- a/siddhi_rust/tests/app_runner_triggers.rs
+++ b/siddhi_rust/tests/app_runner_triggers.rs
@@ -43,3 +43,21 @@ fn cron_trigger_emits() {
     let out = runner.shutdown();
     assert!(out.len() >= 2);
 }
+
+#[test]
+fn parse_periodic_trigger_emits() {
+    let app = "define trigger PT at every 50 ms;";
+    let runner = AppRunner::new(app, "PT");
+    sleep(Duration::from_millis(130));
+    let out = runner.shutdown();
+    assert!(out.len() >= 2);
+}
+
+#[test]
+fn parse_cron_trigger_emits() {
+    let app = "define trigger CronStr at '*/1 * * * * *';";
+    let runner = AppRunner::new(app, "CronStr");
+    sleep(Duration::from_millis(2200));
+    let out = runner.shutdown();
+    assert!(out.len() >= 2);
+}


### PR DESCRIPTION
## Summary
- add a cron trigger test exercising scheduler

## Testing
- `cargo test --test app_runner_triggers`

------
https://chatgpt.com/codex/tasks/task_e_684d63d83b9c8325a16b7872757d9066