### PR TITLE
Implement persistence store backends and table API

### DIFF
--- a/siddhi_rust/Cargo.toml
+++ b/siddhi_rust/Cargo.toml
@@ -22,3 +22,6 @@ rusqlite = { version = "0.29", features = ["bundled"] }
 
 [build-dependencies]
 lalrpop = "0.20"
+
+[dev-dependencies]
+tempfile = "3"

--- a/siddhi_rust/src/core/config/siddhi_context.rs
+++ b/siddhi_rust/src/core/config/siddhi_context.rs
@@ -318,7 +318,7 @@ impl SiddhiContext {
             MaxForeverAttributeAggregatorFactory, MinAttributeAggregatorFactory,
             MinForeverAttributeAggregatorFactory, SumAttributeAggregatorFactory,
         };
-        use crate::core::table::InMemoryTableFactory;
+        use crate::core::table::{InMemoryTableFactory, JdbcTableFactory};
 
         self.add_window_factory("length".to_string(), Box::new(LengthWindowFactory));
         self.add_window_factory("time".to_string(), Box::new(TimeWindowFactory));
@@ -357,6 +357,7 @@ impl SiddhiContext {
         );
 
         self.add_table_factory("inMemory".to_string(), Box::new(InMemoryTableFactory));
+        self.add_table_factory("jdbc".to_string(), Box::new(JdbcTableFactory));
         self.add_source_factory("timer".to_string(), Box::new(TimerSourceFactory));
         self.add_sink_factory("log".to_string(), Box::new(LogSinkFactory));
 

--- a/siddhi_rust/src/core/persistence/mod.rs
+++ b/siddhi_rust/src/core/persistence/mod.rs
@@ -6,6 +6,7 @@ pub mod snapshot_service;
 
 pub use self::data_source::{DataSource, DataSourceConfig};
 pub use self::persistence_store::{
-    InMemoryPersistenceStore, IncrementalPersistenceStore, PersistenceStore,
+    FilePersistenceStore, InMemoryPersistenceStore, IncrementalPersistenceStore, PersistenceStore,
+    SqlitePersistenceStore,
 };
 pub use self::snapshot_service::SnapshotService;

--- a/siddhi_rust/src/core/persistence/persistence_store.rs
+++ b/siddhi_rust/src/core/persistence/persistence_store.rs
@@ -81,3 +81,119 @@ impl IncrementalPersistenceStore for InMemoryPersistenceStore {
         PersistenceStore::clear_all_revisions(self, siddhi_app_id)
     }
 }
+
+// Simple file-based persistence store storing each snapshot as a file
+use std::fs;
+use std::path::{Path, PathBuf};
+
+pub struct FilePersistenceStore {
+    base: PathBuf,
+    last_revision: Mutex<HashMap<String, String>>,
+}
+
+impl FilePersistenceStore {
+    pub fn new<P: Into<PathBuf>>(path: P) -> std::io::Result<Self> {
+        let p = path.into();
+        fs::create_dir_all(&p)?;
+        Ok(Self {
+            base: p,
+            last_revision: Mutex::new(HashMap::new()),
+        })
+    }
+
+    fn file_path(&self, app: &str, rev: &str) -> PathBuf {
+        self.base.join(app).join(rev)
+    }
+}
+
+impl PersistenceStore for FilePersistenceStore {
+    fn save(&self, siddhi_app_id: &str, revision: &str, snapshot: &[u8]) {
+        let dir = self.base.join(siddhi_app_id);
+        if let Err(e) = fs::create_dir_all(&dir) {
+            eprintln!("FilePersistenceStore: cannot create dir: {}", e);
+            return;
+        }
+        let path = self.file_path(siddhi_app_id, revision);
+        if let Err(e) = fs::write(&path, snapshot) {
+            eprintln!("FilePersistenceStore: write failed: {}", e);
+            return;
+        }
+        self.last_revision
+            .lock()
+            .unwrap()
+            .insert(siddhi_app_id.to_string(), revision.to_string());
+    }
+
+    fn load(&self, siddhi_app_id: &str, revision: &str) -> Option<Vec<u8>> {
+        let path = self.file_path(siddhi_app_id, revision);
+        fs::read(path).ok()
+    }
+
+    fn get_last_revision(&self, siddhi_app_id: &str) -> Option<String> {
+        self.last_revision
+            .lock()
+            .unwrap()
+            .get(siddhi_app_id)
+            .cloned()
+    }
+
+    fn clear_all_revisions(&self, siddhi_app_id: &str) {
+        let dir = self.base.join(siddhi_app_id);
+        let _ = fs::remove_dir_all(&dir);
+        self.last_revision.lock().unwrap().remove(siddhi_app_id);
+    }
+}
+
+use rusqlite::{params, Connection};
+
+pub struct SqlitePersistenceStore {
+    conn: Mutex<Connection>,
+}
+
+impl SqlitePersistenceStore {
+    pub fn new<P: AsRef<Path>>(path: P) -> rusqlite::Result<Self> {
+        let conn = Connection::open(path)?;
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS snapshots (app TEXT, rev TEXT, data BLOB, PRIMARY KEY(app, rev))",
+            [],
+        )?;
+        Ok(Self {
+            conn: Mutex::new(conn),
+        })
+    }
+}
+
+impl PersistenceStore for SqlitePersistenceStore {
+    fn save(&self, siddhi_app_id: &str, revision: &str, snapshot: &[u8]) {
+        let conn = self.conn.lock().unwrap();
+        let _ = conn.execute(
+            "INSERT OR REPLACE INTO snapshots(app, rev, data) VALUES (?1, ?2, ?3)",
+            params![siddhi_app_id, revision, snapshot],
+        );
+    }
+
+    fn load(&self, siddhi_app_id: &str, revision: &str) -> Option<Vec<u8>> {
+        let conn = self.conn.lock().unwrap();
+        conn.query_row(
+            "SELECT data FROM snapshots WHERE app=?1 AND rev=?2",
+            params![siddhi_app_id, revision],
+            |row| row.get(0),
+        )
+        .ok()
+    }
+
+    fn get_last_revision(&self, siddhi_app_id: &str) -> Option<String> {
+        let conn = self.conn.lock().unwrap();
+        conn.query_row(
+            "SELECT rev FROM snapshots WHERE app=?1 ORDER BY rowid DESC LIMIT 1",
+            params![siddhi_app_id],
+            |row| row.get(0),
+        )
+        .ok()
+    }
+
+    fn clear_all_revisions(&self, siddhi_app_id: &str) {
+        let conn = self.conn.lock().unwrap();
+        let _ = conn.execute("DELETE FROM snapshots WHERE app=?1", params![siddhi_app_id]);
+    }
+}

--- a/siddhi_rust/src/core/siddhi_app_runtime.rs
+++ b/siddhi_rust/src/core/siddhi_app_runtime.rs
@@ -137,6 +137,13 @@ impl SiddhiAppRuntime {
         self.input_manager.get_input_handler(stream_id)
     }
 
+    pub fn get_table_input_handler(
+        &self,
+        table_id: &str,
+    ) -> Option<crate::core::stream::input::table_input_handler::TableInputHandler> {
+        self.input_manager.get_table_input_handler(table_id)
+    }
+
     pub fn add_callback(
         &self,
         stream_id: &str,

--- a/siddhi_rust/src/core/table/mod.rs
+++ b/siddhi_rust/src/core/table/mod.rs
@@ -4,7 +4,7 @@ use std::sync::RwLock;
 mod jdbc_table;
 use crate::core::config::siddhi_context::SiddhiContext;
 use crate::core::extension::TableFactory;
-pub use jdbc_table::JdbcTable;
+pub use jdbc_table::{JdbcTable, JdbcTableFactory};
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::sync::Arc;

--- a/siddhi_rust/tests/file_persistence.rs
+++ b/siddhi_rust/tests/file_persistence.rs
@@ -1,0 +1,46 @@
+#[path = "common/mod.rs"]
+mod common;
+use common::AppRunner;
+use siddhi_rust::core::event::value::AttributeValue;
+use siddhi_rust::core::persistence::{
+    FilePersistenceStore, PersistenceStore, SqlitePersistenceStore,
+};
+use std::sync::Arc;
+use tempfile::tempdir;
+
+#[test]
+fn persist_restore_file_store() {
+    let dir = tempdir().unwrap();
+    let store: Arc<dyn PersistenceStore> = Arc::new(FilePersistenceStore::new(dir.path()).unwrap());
+    let app = "\
+        @app:name('PersistApp')\n\
+        define stream In (v int);\n\
+        define stream Out (v int);\n\
+        from In#length(2) select v insert into Out;\n";
+    let runner = AppRunner::new_with_store(app, "Out", Arc::clone(&store));
+    runner.send("In", vec![AttributeValue::Int(1)]);
+    let rev = runner.persist();
+    runner.send("In", vec![AttributeValue::Int(2)]);
+    runner.restore_revision(&rev);
+    let _ = runner.shutdown();
+    assert!(!rev.is_empty());
+}
+
+#[test]
+fn persist_restore_sqlite_store() {
+    let file = tempfile::NamedTempFile::new().unwrap();
+    let store: Arc<dyn PersistenceStore> =
+        Arc::new(SqlitePersistenceStore::new(file.path()).unwrap());
+    let app = "\
+        @app:name('PersistApp')\n\
+        define stream In (v int);\n\
+        define stream Out (v int);\n\
+        from In#length(2) select v insert into Out;\n";
+    let runner = AppRunner::new_with_store(app, "Out", Arc::clone(&store));
+    runner.send("In", vec![AttributeValue::Int(1)]);
+    let rev = runner.persist();
+    runner.send("In", vec![AttributeValue::Int(2)]);
+    runner.restore_revision(&rev);
+    let _ = runner.shutdown();
+    assert!(!rev.is_empty());
+}


### PR DESCRIPTION
## Summary
- add `FilePersistenceStore` and `SqlitePersistenceStore`
- register `JdbcTableFactory` in `SiddhiContext`
- expose table handlers through `SiddhiAppRuntime`
- export new persistence stores
- test persisting apps using file and SQLite stores

## Testing
- `cargo test --manifest-path=siddhi_rust/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_684e8484b8b48325afb3c3b68121533a