### PR TITLE
Add SqliteDataSource and concurrent AppRunner test

### DIFF
--- a/siddhi_rust/src/core/persistence/mod.rs
+++ b/siddhi_rust/src/core/persistence/mod.rs
@@ -4,7 +4,7 @@ pub mod data_source;
 pub mod persistence_store; // For PersistenceStore traits
 pub mod snapshot_service;
 
-pub use self::data_source::{DataSource, DataSourceConfig};
+pub use self::data_source::{DataSource, DataSourceConfig, SqliteDataSource};
 pub use self::persistence_store::{
     FilePersistenceStore, InMemoryPersistenceStore, IncrementalPersistenceStore, PersistenceStore,
     SqlitePersistenceStore,

--- a/siddhi_rust/src/core/siddhi_manager.rs
+++ b/siddhi_rust/src/core/siddhi_manager.rs
@@ -232,8 +232,12 @@ impl SiddhiManager {
     }
 
     // Specific method for adding data sources
-    pub fn add_data_source(&self, name: String, data_source: Arc<dyn DataSource>) {
-        self.siddhi_context.add_data_source(name, data_source);
+    pub fn add_data_source(
+        &self,
+        name: String,
+        data_source: Arc<dyn DataSource>,
+    ) -> Result<(), String> {
+        self.siddhi_context.add_data_source(name, data_source)
     }
 
     // set_data_source was a placeholder, replaced by add_data_source

--- a/siddhi_rust/tests/app_runner_stress.rs
+++ b/siddhi_rust/tests/app_runner_stress.rs
@@ -1,0 +1,32 @@
+#[path = "common/mod.rs"]
+mod common;
+use common::AppRunner;
+use siddhi_rust::core::event::value::AttributeValue;
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn concurrent_sends() {
+    let app = "\
+        define stream In (v int);\n\
+        define stream Out (v int);\n\
+        from In select v insert into Out;\n";
+    let runner = Arc::new(AppRunner::new(app, "Out"));
+    let mut handles = Vec::new();
+    for i in 0..4 {
+        let r = Arc::clone(&runner);
+        handles.push(thread::spawn(move || {
+            for k in 0..500 {
+                r.send("In", vec![AttributeValue::Int(i * 500 + k)]);
+            }
+        }));
+    }
+    for h in handles {
+        h.join().unwrap();
+    }
+    thread::sleep(Duration::from_millis(200));
+    let runner = Arc::try_unwrap(runner).expect("arc");
+    let out = runner.shutdown();
+    assert_eq!(out.len(), 2000);
+}

--- a/siddhi_rust/tests/common/mod.rs
+++ b/siddhi_rust/tests/common/mod.rs
@@ -21,6 +21,7 @@ impl StreamCallback for CollectCallback {
     }
 }
 
+#[derive(Debug)]
 pub struct AppRunner {
     runtime: Arc<SiddhiAppRuntime>,
     pub collected: Arc<Mutex<Vec<Vec<AttributeValue>>>>,

--- a/siddhi_rust/tests/data_source_init.rs
+++ b/siddhi_rust/tests/data_source_init.rs
@@ -57,7 +57,7 @@ fn test_add_data_source_uses_config() {
         },
     );
     let ds = Arc::new(MockDataSource::new());
-    ctx.add_data_source("DS".to_string(), ds.clone());
+    ctx.add_data_source("DS".to_string(), ds.clone()).unwrap();
     let stored = ds.called.lock().unwrap().clone();
     assert!(stored.is_some());
     assert_eq!(

--- a/siddhi_rust/tests/jdbc_table.rs
+++ b/siddhi_rust/tests/jdbc_table.rs
@@ -57,10 +57,12 @@ fn setup_table(ctx: &Arc<SiddhiContext>) {
 #[test]
 fn test_jdbc_table_crud() {
     let ctx = Arc::new(SiddhiContext::new());
-    ctx.add_data_source(
-        "DS1".to_string(),
-        Arc::new(SqliteDataSource::new(":memory:")),
-    );
+    ctx
+        .add_data_source(
+            "DS1".to_string(),
+            Arc::new(SqliteDataSource::new(":memory:")),
+        )
+        .unwrap();
     setup_table(&ctx);
 
     let table = JdbcTable::new("test".to_string(), "DS1".to_string(), Arc::clone(&ctx)).unwrap();

--- a/siddhi_rust/tests/table_ops.rs
+++ b/siddhi_rust/tests/table_ops.rs
@@ -154,10 +154,12 @@ fn test_table_input_handler_update_delete_find() {
 #[test]
 fn test_table_input_handler_jdbc() {
     let ctx = Arc::new(SiddhiContext::new());
-    ctx.add_data_source(
-        "DS1".to_string(),
-        Arc::new(SqliteDataSource::new(":memory:")),
-    );
+    ctx
+        .add_data_source(
+            "DS1".to_string(),
+            Arc::new(SqliteDataSource::new(":memory:")),
+        )
+        .unwrap();
     setup_jdbc_table(&ctx, "test2");
 
     let app_ctx = Arc::new(SiddhiAppContext::new(


### PR DESCRIPTION
## Summary
- support SQLite-backed DataSource
- initialize data source on registration and return result
- expose SqliteDataSource in module exports
- add test exercising concurrent sends via AppRunner

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684e8a0ccc5c8325a206222d7b75283e