### PR TITLE
Add dynamic extension loading

### DIFF
--- a/siddhi_rust/Cargo.lock
+++ b/siddhi_rust/Cargo.lock
@@ -182,6 +182,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
+name = "custom_dyn_ext"
+version = "0.1.0"
+dependencies = [
+ "siddhi_rust",
+]
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -224,6 +231,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,6 +251,12 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fixedbitset"
@@ -386,6 +409,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
+name = "libloading"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
+dependencies = [
+ "cfg-if",
+ "windows-targets",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -405,6 +438,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "lock_api"
@@ -682,6 +721,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -736,14 +788,17 @@ dependencies = [
  "chrono",
  "cron",
  "crossbeam-channel",
+ "custom_dyn_ext",
  "lalrpop",
  "lalrpop-util",
+ "libloading",
  "num_cpus",
  "rand",
  "rayon",
  "regex",
  "rusqlite",
  "serde",
+ "tempfile",
  "uuid",
 ]
 
@@ -780,6 +835,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.3",
+ "once_cell",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]

--- a/siddhi_rust/Cargo.toml
+++ b/siddhi_rust/Cargo.toml
@@ -19,9 +19,11 @@ serde = { version = "1", features = ["derive"] }
 rayon = "1"
 num_cpus = "1"
 rusqlite = { version = "0.29", features = ["bundled"] }
+libloading = "0.8"
 
 [build-dependencies]
 lalrpop = "0.20"
 
 [dev-dependencies]
 tempfile = "3"
+custom_dyn_ext = { path = "tests/custom_dyn_ext" }

--- a/siddhi_rust/README.md
+++ b/siddhi_rust/README.md
@@ -113,6 +113,24 @@ let manager = SiddhiManager::new();
 // manager.add_attribute_aggregator_factory("myAgg".to_string(), Box::new(MyAggFactory));
 ```
 
+### Dynamic Extension Loading
+
+Extensions can be compiled into separate crates and loaded at runtime.  A library
+must expose a `register_extension` function that registers factories with a
+`SiddhiManager`.  The integration tests contain a sample dynamic extension under
+`tests/custom_dyn_ext`.
+
+```rust
+let manager = SiddhiManager::new();
+let lib_path = custom_dyn_ext::library_path();
+manager
+    .set_extension("custom", lib_path.to_str().unwrap().to_string())
+    .unwrap();
+```
+
+Once loaded, the factories provided by the library can be used like any other
+registered extension.
+
 ### Example Usage
 
 ```rust

--- a/siddhi_rust/src/core/extension/mod.rs
+++ b/siddhi_rust/src/core/extension/mod.rs
@@ -12,6 +12,7 @@ use crate::core::query::selector::attribute::aggregator::AttributeAggregatorExec
 use crate::query_api::execution::query::input::handler::WindowHandler;
 
 pub trait WindowProcessorFactory: Debug + Send + Sync {
+    fn name(&self) -> &'static str;
     fn create(
         &self,
         handler: &WindowHandler,
@@ -27,6 +28,7 @@ impl Clone for Box<dyn WindowProcessorFactory> {
 }
 
 pub trait AttributeAggregatorFactory: Debug + Send + Sync {
+    fn name(&self) -> &'static str;
     fn create(&self) -> Box<dyn AttributeAggregatorExecutor>;
     fn clone_box(&self) -> Box<dyn AttributeAggregatorFactory>;
 }
@@ -37,6 +39,7 @@ impl Clone for Box<dyn AttributeAggregatorFactory> {
 }
 
 pub trait SourceFactory: Debug + Send + Sync {
+    fn name(&self) -> &'static str;
     fn create(&self) -> Box<dyn crate::core::stream::input::source::Source>;
     fn clone_box(&self) -> Box<dyn SourceFactory>;
 }
@@ -47,6 +50,7 @@ impl Clone for Box<dyn SourceFactory> {
 }
 
 pub trait SinkFactory: Debug + Send + Sync {
+    fn name(&self) -> &'static str;
     fn create(&self) -> Box<dyn crate::core::stream::output::sink::Sink>;
     fn clone_box(&self) -> Box<dyn SinkFactory>;
 }
@@ -57,6 +61,7 @@ impl Clone for Box<dyn SinkFactory> {
 }
 
 pub trait StoreFactory: Debug + Send + Sync {
+    fn name(&self) -> &'static str;
     fn clone_box(&self) -> Box<dyn StoreFactory>;
 }
 impl Clone for Box<dyn StoreFactory> {
@@ -66,6 +71,7 @@ impl Clone for Box<dyn StoreFactory> {
 }
 
 pub trait SourceMapperFactory: Debug + Send + Sync {
+    fn name(&self) -> &'static str;
     fn clone_box(&self) -> Box<dyn SourceMapperFactory>;
 }
 impl Clone for Box<dyn SourceMapperFactory> {
@@ -75,6 +81,7 @@ impl Clone for Box<dyn SourceMapperFactory> {
 }
 
 pub trait SinkMapperFactory: Debug + Send + Sync {
+    fn name(&self) -> &'static str;
     fn clone_box(&self) -> Box<dyn SinkMapperFactory>;
 }
 impl Clone for Box<dyn SinkMapperFactory> {
@@ -84,6 +91,7 @@ impl Clone for Box<dyn SinkMapperFactory> {
 }
 
 pub trait TableFactory: Debug + Send + Sync {
+    fn name(&self) -> &'static str;
     fn create(
         &self,
         table_name: String,
@@ -102,6 +110,7 @@ impl Clone for Box<dyn TableFactory> {
 pub struct TimerSourceFactory;
 
 impl SourceFactory for TimerSourceFactory {
+    fn name(&self) -> &'static str { "timer" }
     fn create(&self) -> Box<dyn crate::core::stream::input::source::Source> {
         Box::new(crate::core::stream::input::source::timer_source::TimerSource::new(1000))
     }
@@ -114,6 +123,7 @@ impl SourceFactory for TimerSourceFactory {
 pub struct LogSinkFactory;
 
 impl SinkFactory for LogSinkFactory {
+    fn name(&self) -> &'static str { "log" }
     fn create(&self) -> Box<dyn crate::core::stream::output::sink::Sink> {
         Box::new(crate::core::stream::output::sink::LogSink::new())
     }

--- a/siddhi_rust/src/core/query/processor/stream/window/mod.rs
+++ b/siddhi_rust/src/core/query/processor/stream/window/mod.rs
@@ -348,6 +348,7 @@ pub fn create_window_processor(
 pub struct LengthWindowFactory;
 
 impl WindowProcessorFactory for LengthWindowFactory {
+    fn name(&self) -> &'static str { "length" }
     fn create(
         &self,
         handler: &WindowHandler,
@@ -368,6 +369,7 @@ impl WindowProcessorFactory for LengthWindowFactory {
 pub struct TimeWindowFactory;
 
 impl WindowProcessorFactory for TimeWindowFactory {
+    fn name(&self) -> &'static str { "time" }
     fn create(
         &self,
         handler: &WindowHandler,
@@ -526,6 +528,7 @@ impl WindowProcessor for LengthBatchWindowProcessor {}
 pub struct LengthBatchWindowFactory;
 
 impl WindowProcessorFactory for LengthBatchWindowFactory {
+    fn name(&self) -> &'static str { "lengthBatch" }
     fn create(
         &self,
         handler: &WindowHandler,
@@ -713,6 +716,7 @@ impl WindowProcessor for TimeBatchWindowProcessor {}
 pub struct TimeBatchWindowFactory;
 
 impl WindowProcessorFactory for TimeBatchWindowFactory {
+    fn name(&self) -> &'static str { "timeBatch" }
     fn create(
         &self,
         handler: &WindowHandler,

--- a/siddhi_rust/src/core/query/selector/attribute/aggregator/mod.rs
+++ b/siddhi_rust/src/core/query/selector/attribute/aggregator/mod.rs
@@ -568,6 +568,7 @@ use crate::core::extension::AttributeAggregatorFactory;
 pub struct SumAttributeAggregatorFactory;
 
 impl AttributeAggregatorFactory for SumAttributeAggregatorFactory {
+    fn name(&self) -> &'static str { "sum" }
     fn create(&self) -> Box<dyn AttributeAggregatorExecutor> {
         Box::new(SumAttributeAggregatorExecutor::default())
     }
@@ -580,6 +581,7 @@ impl AttributeAggregatorFactory for SumAttributeAggregatorFactory {
 pub struct AvgAttributeAggregatorFactory;
 
 impl AttributeAggregatorFactory for AvgAttributeAggregatorFactory {
+    fn name(&self) -> &'static str { "avg" }
     fn create(&self) -> Box<dyn AttributeAggregatorExecutor> {
         Box::new(AvgAttributeAggregatorExecutor::default())
     }
@@ -592,6 +594,7 @@ impl AttributeAggregatorFactory for AvgAttributeAggregatorFactory {
 pub struct CountAttributeAggregatorFactory;
 
 impl AttributeAggregatorFactory for CountAttributeAggregatorFactory {
+    fn name(&self) -> &'static str { "count" }
     fn create(&self) -> Box<dyn AttributeAggregatorExecutor> {
         Box::new(CountAttributeAggregatorExecutor::default())
     }
@@ -604,6 +607,7 @@ impl AttributeAggregatorFactory for CountAttributeAggregatorFactory {
 pub struct DistinctCountAttributeAggregatorFactory;
 
 impl AttributeAggregatorFactory for DistinctCountAttributeAggregatorFactory {
+    fn name(&self) -> &'static str { "distinctCount" }
     fn create(&self) -> Box<dyn AttributeAggregatorExecutor> {
         Box::new(DistinctCountAttributeAggregatorExecutor::default())
     }
@@ -616,6 +620,7 @@ impl AttributeAggregatorFactory for DistinctCountAttributeAggregatorFactory {
 pub struct MinAttributeAggregatorFactory;
 
 impl AttributeAggregatorFactory for MinAttributeAggregatorFactory {
+    fn name(&self) -> &'static str { "min" }
     fn create(&self) -> Box<dyn AttributeAggregatorExecutor> {
         Box::new(MinAttributeAggregatorExecutor::default())
     }
@@ -628,6 +633,7 @@ impl AttributeAggregatorFactory for MinAttributeAggregatorFactory {
 pub struct MaxAttributeAggregatorFactory;
 
 impl AttributeAggregatorFactory for MaxAttributeAggregatorFactory {
+    fn name(&self) -> &'static str { "max" }
     fn create(&self) -> Box<dyn AttributeAggregatorExecutor> {
         Box::new(MaxAttributeAggregatorExecutor::default())
     }
@@ -640,6 +646,7 @@ impl AttributeAggregatorFactory for MaxAttributeAggregatorFactory {
 pub struct MinForeverAttributeAggregatorFactory;
 
 impl AttributeAggregatorFactory for MinForeverAttributeAggregatorFactory {
+    fn name(&self) -> &'static str { "minForever" }
     fn create(&self) -> Box<dyn AttributeAggregatorExecutor> {
         Box::new(MinForeverAttributeAggregatorExecutor::default())
     }
@@ -652,6 +659,7 @@ impl AttributeAggregatorFactory for MinForeverAttributeAggregatorFactory {
 pub struct MaxForeverAttributeAggregatorFactory;
 
 impl AttributeAggregatorFactory for MaxForeverAttributeAggregatorFactory {
+    fn name(&self) -> &'static str { "maxForever" }
     fn create(&self) -> Box<dyn AttributeAggregatorExecutor> {
         Box::new(MaxForeverAttributeAggregatorExecutor::default())
     }

--- a/siddhi_rust/src/core/table/jdbc_table.rs
+++ b/siddhi_rust/src/core/table/jdbc_table.rs
@@ -144,6 +144,7 @@ impl Table for JdbcTable {
 pub struct JdbcTableFactory;
 
 impl crate::core::extension::TableFactory for JdbcTableFactory {
+    fn name(&self) -> &'static str { "jdbc" }
     fn create(
         &self,
         table_name: String,

--- a/siddhi_rust/src/core/table/mod.rs
+++ b/siddhi_rust/src/core/table/mod.rs
@@ -105,6 +105,7 @@ impl Table for InMemoryTable {
 pub struct InMemoryTableFactory;
 
 impl TableFactory for InMemoryTableFactory {
+    fn name(&self) -> &'static str { "inMemory" }
     fn create(
         &self,
         _name: String,

--- a/siddhi_rust/tests/custom_dyn_ext/Cargo.toml
+++ b/siddhi_rust/tests/custom_dyn_ext/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "custom_dyn_ext"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+siddhi_rust = { path = "../.." }

--- a/siddhi_rust/tests/custom_dyn_ext/src/lib.rs
+++ b/siddhi_rust/tests/custom_dyn_ext/src/lib.rs
@@ -1,0 +1,79 @@
+use std::sync::{Arc, Mutex};
+use siddhi_rust::core::config::{siddhi_app_context::SiddhiAppContext, siddhi_query_context::SiddhiQueryContext};
+use siddhi_rust::core::event::complex_event::ComplexEvent;
+use siddhi_rust::core::event::value::AttributeValue;
+use siddhi_rust::core::extension::{AttributeAggregatorFactory, WindowProcessorFactory};
+use siddhi_rust::core::executor::expression_executor::ExpressionExecutor;
+use siddhi_rust::core::query::processor::{CommonProcessorMeta, ProcessingMode, Processor};
+use siddhi_rust::core::query::processor::stream::window::WindowProcessor;
+use siddhi_rust::core::query::selector::attribute::aggregator::AttributeAggregatorExecutor;
+use siddhi_rust::core::siddhi_manager::SiddhiManager;
+use siddhi_rust::query_api::definition::attribute::Type as AttrType;
+use siddhi_rust::query_api::execution::query::input::handler::WindowHandler;
+
+#[derive(Debug)]
+struct DynWindowProcessor {
+    meta: CommonProcessorMeta,
+}
+
+impl Processor for DynWindowProcessor {
+    fn process(&self, _c: Option<Box<dyn ComplexEvent>>) {}
+    fn next_processor(&self) -> Option<Arc<Mutex<dyn Processor>>> { None }
+    fn set_next_processor(&mut self, _next: Option<Arc<Mutex<dyn Processor>>>) {}
+    fn clone_processor(&self, q: &Arc<SiddhiQueryContext>) -> Box<dyn Processor> {
+        Box::new(DynWindowProcessor { meta: CommonProcessorMeta::new(Arc::clone(&self.meta.siddhi_app_context), Arc::clone(q)) })
+    }
+    fn get_siddhi_app_context(&self) -> Arc<SiddhiAppContext> { Arc::clone(&self.meta.siddhi_app_context) }
+    fn get_processing_mode(&self) -> ProcessingMode { ProcessingMode::BATCH }
+    fn is_stateful(&self) -> bool { false }
+}
+impl WindowProcessor for DynWindowProcessor {}
+
+#[derive(Debug, Clone)]
+struct DynWindowFactory;
+impl WindowProcessorFactory for DynWindowFactory {
+    fn name(&self) -> &'static str { "dynWindow" }
+    fn create(&self, _h: &WindowHandler, app: Arc<SiddhiAppContext>, q: Arc<SiddhiQueryContext>) -> Result<Arc<Mutex<dyn Processor>>, String> {
+        Ok(Arc::new(Mutex::new(DynWindowProcessor { meta: CommonProcessorMeta::new(app, q) })))
+    }
+    fn clone_box(&self) -> Box<dyn WindowProcessorFactory> { Box::new(self.clone()) }
+}
+
+#[derive(Debug, Clone)]
+struct DynAggFactory;
+#[derive(Debug, Default)]
+struct DynAggExec;
+impl AttributeAggregatorFactory for DynAggFactory {
+    fn name(&self) -> &'static str { "dynConstAgg" }
+    fn create(&self) -> Box<dyn AttributeAggregatorExecutor> { Box::new(DynAggExec::default()) }
+    fn clone_box(&self) -> Box<dyn AttributeAggregatorFactory> { Box::new(self.clone()) }
+}
+impl AttributeAggregatorExecutor for DynAggExec {
+    fn init(&mut self, _e: Vec<Box<dyn ExpressionExecutor>>, _m: ProcessingMode, _ex: bool, _c: &SiddhiQueryContext) -> Result<(), String> { Ok(()) }
+    fn process_add(&self, _d: Option<AttributeValue>) -> Option<AttributeValue> { Some(AttributeValue::Int(7)) }
+    fn process_remove(&self, _d: Option<AttributeValue>) -> Option<AttributeValue> { Some(AttributeValue::Int(7)) }
+    fn reset(&self) -> Option<AttributeValue> { Some(AttributeValue::Int(7)) }
+    fn clone_box(&self) -> Box<dyn AttributeAggregatorExecutor> { Box::new(DynAggExec::default()) }
+}
+impl ExpressionExecutor for DynAggExec {
+    fn execute(&self, _e: Option<&dyn ComplexEvent>) -> Option<AttributeValue> { Some(AttributeValue::Int(7)) }
+    fn get_return_type(&self) -> AttrType { AttrType::INT }
+    fn clone_executor(&self, _c: &Arc<SiddhiAppContext>) -> Box<dyn ExpressionExecutor> { Box::new(DynAggExec::default()) }
+    fn is_attribute_aggregator(&self) -> bool { true }
+}
+
+#[no_mangle]
+pub extern "C" fn register_extension(manager: &SiddhiManager) {
+    manager.add_window_factory("dynWindow".to_string(), Box::new(DynWindowFactory));
+    manager.add_attribute_aggregator_factory("dynConstAgg".to_string(), Box::new(DynAggFactory));
+}
+
+/// Returns the path to the compiled dynamic library for this crate.
+pub fn library_path() -> std::path::PathBuf {
+    use std::path::PathBuf;
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("../../target/debug/deps");
+    p = p.canonicalize().unwrap_or(p);
+    p.push(format!("{}custom_dyn_ext.{}", std::env::consts::DLL_PREFIX, std::env::consts::DLL_EXTENSION));
+    p
+}

--- a/siddhi_rust/tests/dynamic_ext_integration.rs
+++ b/siddhi_rust/tests/dynamic_ext_integration.rs
@@ -1,0 +1,43 @@
+use std::sync::Arc;
+use siddhi_rust::core::config::{siddhi_app_context::SiddhiAppContext, siddhi_query_context::SiddhiQueryContext};
+use siddhi_rust::core::siddhi_manager::SiddhiManager;
+use siddhi_rust::core::util::parser::{ExpressionParserContext, parse_expression};
+use siddhi_rust::query_api::definition::attribute::Type as AttrType;
+use siddhi_rust::query_api::definition::StreamDefinition;
+use siddhi_rust::query_api::expression::Expression;
+use siddhi_rust::query_api::siddhi_app::SiddhiApp;
+
+#[test]
+fn test_dynamic_extension_loading() {
+    let manager = SiddhiManager::new();
+    let lib_path = custom_dyn_ext::library_path();
+    manager.set_extension("dynlib", lib_path.to_str().unwrap().to_string()).unwrap();
+
+    // verify window factory registered
+    let ctx = manager.siddhi_context();
+    assert!(ctx.get_window_factory("dynWindow").is_some());
+    assert!(ctx.get_attribute_aggregator_factory("dynConstAgg").is_some());
+
+    // Use custom aggregator via expression parser
+    let app = Arc::new(SiddhiApp::new("app".to_string()));
+    let app_ctx = Arc::new(SiddhiAppContext::new(ctx, "app".to_string(), Arc::clone(&app), String::new()));
+    let q_ctx = Arc::new(SiddhiQueryContext::new(Arc::clone(&app_ctx), "q".to_string(), None));
+    let stream_def = Arc::new(StreamDefinition::new("S".to_string()).attribute("v".to_string(), AttrType::INT));
+    let meta = siddhi_rust::core::event::stream::meta_stream_event::MetaStreamEvent::new_for_single_input(Arc::clone(&stream_def));
+    let mut map = std::collections::HashMap::new();
+    map.insert("S".to_string(), Arc::new(meta));
+    let parse_ctx = ExpressionParserContext {
+        siddhi_app_context: app_ctx,
+        siddhi_query_context: q_ctx,
+        stream_meta_map: map,
+        table_meta_map: std::collections::HashMap::new(),
+        window_meta_map: std::collections::HashMap::new(),
+        aggregation_meta_map: std::collections::HashMap::new(),
+        state_meta_map: std::collections::HashMap::new(),
+        default_source: "S".to_string(),
+        query_name: "Q",
+    };
+    let expr = Expression::function_no_ns("dynConstAgg".to_string(), vec![]);
+    let exec = parse_expression(&expr, &parse_ctx).unwrap();
+    assert_eq!(exec.execute(None), Some(siddhi_rust::core::event::value::AttributeValue::Int(7)));
+}

--- a/siddhi_rust/tests/extensions.rs
+++ b/siddhi_rust/tests/extensions.rs
@@ -62,6 +62,7 @@ impl WindowProcessor for DummyWindowProcessor {}
 #[derive(Debug, Clone)]
 struct DummyWindowFactory;
 impl WindowProcessorFactory for DummyWindowFactory {
+    fn name(&self) -> &'static str { "dummy" }
     fn create(
         &self,
         _h: &WindowHandler,
@@ -82,6 +83,7 @@ struct ConstAggFactory;
 #[derive(Debug, Default)]
 struct ConstAggExec;
 impl AttributeAggregatorFactory for ConstAggFactory {
+    fn name(&self) -> &'static str { "constAgg" }
     fn create(
         &self,
     ) -> Box<
@@ -287,6 +289,7 @@ fn test_table_factory_invoked() {
     #[derive(Debug, Clone)]
     struct RecordingFactory;
     impl siddhi_rust::core::extension::TableFactory for RecordingFactory {
+        fn name(&self) -> &'static str { "rec" }
         fn create(
             &self,
             _n: String,


### PR DESCRIPTION
## Summary
- flesh out extension traits with `name()` method
- implement dynamic library loading in `SiddhiManager::set_extension`
- provide sample dynamic extension crate
- add integration test for dynamic extension

## Testing
- `cargo test --test dynamic_ext_integration -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_684e8dd329ac832597b7aa00ca790ef3