### PR TITLE
Add location-aware expression parse errors

### DIFF
--- a/siddhi_rust/src/core/util/parser/mod.rs
+++ b/siddhi_rust/src/core/util/parser/mod.rs
@@ -8,7 +8,7 @@ pub mod trigger_parser;
 // pub mod aggregation_parser;
 // ... etc.
 
-pub use self::expression_parser::{parse_expression, ExpressionParserContext};
+pub use self::expression_parser::{parse_expression, ExpressionParserContext, ExpressionParseError};
 pub use self::query_parser::QueryParser; // Added
 pub use self::siddhi_app_parser::SiddhiAppParser; // Added
 pub use self::trigger_parser::TriggerParser;

--- a/siddhi_rust/tests/expression_parser_complex.rs
+++ b/siddhi_rust/tests/expression_parser_complex.rs
@@ -119,10 +119,13 @@ fn test_variable_not_found_error() {
         query_name: "Q3",
     };
 
-    let var_b = Variable::new("missing".to_string()).of_stream("A".to_string());
+    let mut var_b = Variable::new("missing".to_string()).of_stream("A".to_string());
+    var_b.siddhi_element.query_context_start_index = Some((10, 5));
     let expr = Expression::Variable(var_b);
     let err = parse_expression(&expr, &ctx).unwrap_err();
-    assert!(err.contains("Q3"));
+    assert_eq!(err.line, Some(10));
+    assert_eq!(err.column, Some(5));
+    assert_eq!(err.query_name, "Q3");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- propagate parsing context via `ExpressionParseError`
- update query parser to forward error details
- test for line/column info on invalid expressions

## Testing
- `cargo test --no-run`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684eae7231708325b00735c9f6f7be32