### PR TITLE
Implement select processor grouping features

### DIFF
--- a/siddhi_rust/tests/app_runner_selector.rs
+++ b/siddhi_rust/tests/app_runner_selector.rs
@@ -20,6 +20,53 @@ fn group_by_having_order_limit_offset() {
         ],
     );
     let out = runner.shutdown();
-    assert_eq!(out, vec![vec![AttributeValue::Int(1), AttributeValue::Long(7)]]);
+    assert_eq!(
+        out,
+        vec![vec![AttributeValue::Int(1), AttributeValue::Long(7)]]
+    );
 }
 
+#[test]
+fn group_by_having_order_asc() {
+    let app = "\
+        define stream In (a int, b int);\n\
+        define stream Out (b int, s long);\n\
+        from In select b, sum(a) as s group by b having sum(a) >= 3 order by b asc insert into Out;\n";
+    let runner = AppRunner::new(app, "Out");
+    runner.send_batch(
+        "In",
+        vec![
+            vec![AttributeValue::Int(1), AttributeValue::Int(2)],
+            vec![AttributeValue::Int(2), AttributeValue::Int(1)],
+            vec![AttributeValue::Int(3), AttributeValue::Int(1)],
+            vec![AttributeValue::Int(2), AttributeValue::Int(2)],
+        ],
+    );
+    let out = runner.shutdown();
+    let expected = vec![
+        vec![AttributeValue::Int(1), AttributeValue::Long(5)],
+        vec![AttributeValue::Int(2), AttributeValue::Long(3)],
+    ];
+    assert_eq!(out, expected);
+}
+
+#[test]
+fn order_by_desc_limit_offset() {
+    let app = "\
+        define stream In (a int);\n\
+        define stream Out (a int);\n\
+        from In select a order by a desc limit 2 offset 1 insert into Out;\n";
+    let runner = AppRunner::new(app, "Out");
+    runner.send_batch(
+        "In",
+        vec![
+            vec![AttributeValue::Int(1)],
+            vec![AttributeValue::Int(5)],
+            vec![AttributeValue::Int(3)],
+            vec![AttributeValue::Int(2)],
+        ],
+    );
+    let out = runner.shutdown();
+    let expected = vec![vec![AttributeValue::Int(3)], vec![AttributeValue::Int(2)]];
+    assert_eq!(out, expected);
+}


### PR DESCRIPTION
## Summary
- support group by, having, order by with limit/offset in SelectProcessor
- pass these selections through the query parser
- test selector features with AppRunner

## Testing
- `cargo test --quiet --test app_runner_selector -- --nocapture`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_684f9864a49c8325bc6e65192e4ae182