### PR TITLE
Add UDF lookup and placeholder script functions

### DIFF
--- a/siddhi_rust/src/core/config/siddhi_app_context.rs
+++ b/siddhi_rust/src/core/config/siddhi_app_context.rs
@@ -28,6 +28,18 @@ use crate::core::persistence::SnapshotService;
 use crate::core::util::thread_barrier::ThreadBarrier;
 #[derive(Debug, Clone, Default)]
 pub struct ScriptPlaceholder {}
+#[derive(Debug, Clone)]
+pub struct ScriptFunctionPlaceholder {
+    pub return_type: crate::query_api::definition::attribute::Type,
+}
+
+impl Default for ScriptFunctionPlaceholder {
+    fn default() -> Self {
+        Self {
+            return_type: crate::query_api::definition::attribute::Type::OBJECT,
+        }
+    }
+}
 #[derive(Debug, Clone, Default)]
 pub struct TriggerPlaceholder {}
 #[derive(Debug, Clone, Default)]
@@ -92,7 +104,8 @@ pub struct SiddhiAppContext {
     // Simplified placeholder fields for now
     _external_refs_placeholder: Vec<String>,
     _triggers_placeholder: Vec<String>,
-    _scripts_placeholder: HashMap<String, String>,
+    /// Placeholder storage for script functions keyed by name.
+    pub script_function_map: HashMap<String, ScriptFunctionPlaceholder>,
     _schedulers_placeholder: Vec<String>,
 }
 
@@ -163,9 +176,27 @@ impl SiddhiAppContext {
             // scheduler_list: Vec::new(),
             _external_refs_placeholder: Vec::new(),
             _triggers_placeholder: Vec::new(),
-            _scripts_placeholder: HashMap::new(),
+            script_function_map: HashMap::new(),
             _schedulers_placeholder: Vec::new(),
         }
+    }
+
+    /// Register a script function with the given name and return type.
+    pub fn add_script_function(
+        &mut self,
+        name: String,
+        return_type: crate::query_api::definition::attribute::Type,
+    ) {
+        self.script_function_map
+            .insert(name, ScriptFunctionPlaceholder { return_type });
+    }
+
+    /// Lookup a registered script function placeholder by name.
+    pub fn get_script_function(
+        &self,
+        name: &str,
+    ) -> Option<&ScriptFunctionPlaceholder> {
+        self.script_function_map.get(name)
     }
 
     // --- Getter and Setter examples ---

--- a/siddhi_rust/src/core/executor/function/mod.rs
+++ b/siddhi_rust/src/core/executor/function/mod.rs
@@ -9,6 +9,7 @@ pub mod event_timestamp_function_executor;
 pub mod if_then_else_function_executor;
 pub mod instance_of_checkers;
 pub mod math_functions;
+pub mod script_function_executor;
 pub mod scalar_function_executor; // Added
 pub mod string_functions;
 pub mod uuid_function_executor;
@@ -24,6 +25,7 @@ pub use self::event_timestamp_function_executor::EventTimestampFunctionExecutor;
 pub use self::if_then_else_function_executor::IfThenElseFunctionExecutor;
 pub use self::instance_of_checkers::*;
 pub use self::math_functions::{RoundFunctionExecutor, SqrtFunctionExecutor};
+pub use self::script_function_executor::ScriptFunctionExecutor;
 pub use self::scalar_function_executor::ScalarFunctionExecutor; // Added
 pub use self::string_functions::{ConcatFunctionExecutor, LengthFunctionExecutor};
 pub use self::uuid_function_executor::UuidFunctionExecutor;

--- a/siddhi_rust/src/core/executor/function/script_function_executor.rs
+++ b/siddhi_rust/src/core/executor/function/script_function_executor.rs
@@ -1,0 +1,54 @@
+use crate::core::config::siddhi_app_context::SiddhiAppContext;
+use crate::core::event::complex_event::ComplexEvent;
+use crate::core::event::value::AttributeValue;
+use crate::core::executor::expression_executor::ExpressionExecutor;
+use crate::core::executor::function::scalar_function_executor::ScalarFunctionExecutor;
+use crate::query_api::definition::attribute::Type as ApiAttributeType;
+use std::sync::Arc;
+
+#[derive(Debug, Clone)]
+pub struct ScriptFunctionExecutor {
+    name: String,
+    return_type: ApiAttributeType,
+}
+
+impl ScriptFunctionExecutor {
+    pub fn new(name: String, return_type: ApiAttributeType) -> Self {
+        Self { name, return_type }
+    }
+}
+
+impl ExpressionExecutor for ScriptFunctionExecutor {
+    fn execute(&self, _event: Option<&dyn ComplexEvent>) -> Option<AttributeValue> {
+        eprintln!("Script function '{}' not implemented", self.name);
+        Some(AttributeValue::Null)
+    }
+
+    fn get_return_type(&self) -> ApiAttributeType {
+        self.return_type
+    }
+
+    fn clone_executor(&self, _ctx: &Arc<SiddhiAppContext>) -> Box<dyn ExpressionExecutor> {
+        Box::new(self.clone())
+    }
+}
+
+impl ScalarFunctionExecutor for ScriptFunctionExecutor {
+    fn init(
+        &mut self,
+        _args: &Vec<Box<dyn ExpressionExecutor>>,
+        _ctx: &Arc<SiddhiAppContext>,
+    ) -> Result<(), String> {
+        Ok(())
+    }
+
+    fn destroy(&mut self) {}
+
+    fn get_name(&self) -> String {
+        self.name.clone()
+    }
+
+    fn clone_scalar_function(&self) -> Box<dyn ScalarFunctionExecutor> {
+        Box::new(self.clone())
+    }
+}

--- a/siddhi_rust/src/core/util/parser/expression_parser.rs
+++ b/siddhi_rust/src/core/util/parser/expression_parser.rs
@@ -563,6 +563,23 @@ pub fn parse_expression<'a>(
                                 ExpressionParseError::new(e, &api_func.siddhi_element, context.query_name)
                             })?,
                         ))
+                    } else if let Some(script_fn) = context
+                        .siddhi_app_context
+                        .get_script_function(&function_lookup_name)
+                    {
+                        Ok(Box::new(
+                            AttributeFunctionExpressionExecutor::new(
+                                Box::new(ScriptFunctionExecutor::new(
+                                    function_lookup_name.clone(),
+                                    script_fn.return_type,
+                                )),
+                                arg_execs,
+                                Arc::clone(&context.siddhi_app_context),
+                            )
+                            .map_err(|e| {
+                                ExpressionParseError::new(e, &api_func.siddhi_element, context.query_name)
+                            })?,
+                        ))
                     } else {
                         Err(ExpressionParseError::new(
                             format!("Unsupported or unknown function: {}", function_lookup_name),

--- a/siddhi_rust/tests/udf_invocation.rs
+++ b/siddhi_rust/tests/udf_invocation.rs
@@ -1,0 +1,62 @@
+#[path = "common/mod.rs"]
+mod common;
+use common::AppRunner;
+use siddhi_rust::core::config::siddhi_app_context::SiddhiAppContext;
+use siddhi_rust::core::executor::expression_executor::ExpressionExecutor;
+use siddhi_rust::core::executor::function::scalar_function_executor::ScalarFunctionExecutor;
+use siddhi_rust::core::siddhi_manager::SiddhiManager;
+use siddhi_rust::query_api::definition::attribute::Type as AttrType;
+use siddhi_rust::query_api::siddhi_app::SiddhiApp;
+use std::sync::Arc;
+use siddhi_rust::core::event::value::AttributeValue;
+
+#[derive(Debug, Default)]
+struct PlusOneFn {
+    arg: Option<Box<dyn ExpressionExecutor>>,
+}
+
+impl Clone for PlusOneFn {
+    fn clone(&self) -> Self { Self { arg: None } }
+}
+
+impl ExpressionExecutor for PlusOneFn {
+    fn execute(&self, event: Option<&dyn siddhi_rust::core::event::complex_event::ComplexEvent>) -> Option<AttributeValue> {
+        let v = self.arg.as_ref()?.execute(event)?;
+        match v {
+            AttributeValue::Int(i) => Some(AttributeValue::Int(i + 1)),
+            _ => None,
+        }
+    }
+
+    fn get_return_type(&self) -> AttrType { AttrType::INT }
+
+    fn clone_executor(&self, _ctx: &Arc<SiddhiAppContext>) -> Box<dyn ExpressionExecutor> {
+        Box::new(self.clone())
+    }
+}
+
+impl ScalarFunctionExecutor for PlusOneFn {
+    fn init(&mut self, args: &Vec<Box<dyn ExpressionExecutor>>, ctx: &Arc<SiddhiAppContext>) -> Result<(), String> {
+        if args.len() != 1 { return Err("plusOne expects one argument".to_string()); }
+        self.arg = Some(args[0].clone_executor(ctx));
+        Ok(())
+    }
+    fn destroy(&mut self) {}
+    fn get_name(&self) -> String { "plusOne".to_string() }
+    fn clone_scalar_function(&self) -> Box<dyn ScalarFunctionExecutor> { Box::new(self.clone()) }
+}
+
+#[test]
+fn udf_invoked_in_query() {
+    let mut manager = SiddhiManager::new();
+    manager.add_scalar_function_factory("plusOne".to_string(), Box::new(PlusOneFn::default()));
+
+    let app = "\
+        define stream In (v int);\n\
+        define stream Out (v int);\n\
+        from In select plusOne(v) as v insert into Out;\n";
+    let runner = AppRunner::new_with_manager(manager, app, "Out");
+    runner.send("In", vec![AttributeValue::Int(1)]);
+    let out = runner.shutdown();
+    assert_eq!(out, vec![vec![AttributeValue::Int(2)]]);
+}


### PR DESCRIPTION
## Summary
- support placeholder script functions
- resolve script functions during expression parsing
- expose methods for registering script functions in `SiddhiAppContext`
- add runtime test covering UDF invocation via SiddhiQL

## Testing
- `cargo test --tests --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684fabd6304c83259d3d0ba5a4c38db4