### PR TITLE
Add persistence store CLI option

### DIFF
--- a/siddhi_rust/src/bin/run_siddhi.rs
+++ b/siddhi_rust/src/bin/run_siddhi.rs
@@ -3,17 +3,41 @@ use std::fs;
 use std::thread;
 use std::time::Duration;
 
+use siddhi_rust::core::persistence::{
+    FilePersistenceStore, PersistenceStore, SqlitePersistenceStore,
+};
 use siddhi_rust::core::siddhi_manager::SiddhiManager;
 use siddhi_rust::core::stream::output::sink::LogSink;
+use std::sync::Arc;
 
 fn main() {
     let args: Vec<String> = env::args().collect();
     if args.len() < 2 {
-        eprintln!("Usage: {} <siddhi_file>", args[0]);
+        eprintln!(
+            "Usage: {} <siddhi_file> [--store file:<dir>|sqlite:<file>]",
+            args[0]
+        );
         std::process::exit(1);
     }
 
     let file = &args[1];
+    let mut store: Option<Arc<dyn PersistenceStore>> = None;
+    if args.len() >= 4 && args[2] == "--store" {
+        let spec = &args[3];
+        if let Some(path) = spec.strip_prefix("file:") {
+            match FilePersistenceStore::new(path) {
+                Ok(s) => store = Some(Arc::new(s)),
+                Err(e) => eprintln!("Failed to initialize file store: {}", e),
+            }
+        } else if let Some(path) = spec.strip_prefix("sqlite:") {
+            match SqlitePersistenceStore::new(path) {
+                Ok(s) => store = Some(Arc::new(s)),
+                Err(e) => eprintln!("Failed to initialize sqlite store: {}", e),
+            }
+        } else {
+            eprintln!("Unknown store specification '{}'", spec);
+        }
+    }
     let content = match fs::read_to_string(file) {
         Ok(c) => c,
         Err(e) => {
@@ -23,6 +47,9 @@ fn main() {
     };
 
     let manager = SiddhiManager::new();
+    if let Some(s) = store {
+        manager.set_persistence_store(s);
+    }
     let runtime = match manager.create_siddhi_app_runtime_from_string(&content) {
         Ok(rt) => rt,
         Err(e) => {


### PR DESCRIPTION
## Summary
- add ability to select persistence store when running Siddhi apps
- keep file and SQLite stores for snapshots
- tests already cover persisting and restoring state

## Testing
- `cargo test --quiet --test file_persistence -- --test-threads=1`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6850e3f8936083259a6d7ddafc755e9b