### PR TITLE
Implement basic trigger runtime

### DIFF
--- a/siddhi_rust/README.md
+++ b/siddhi_rust/README.md
@@ -51,7 +51,7 @@ This port is **far from feature-complete** with the Java version. Users should b
     *   `SiddhiAppParser` & `QueryParser` now construct runtimes with windows, joins, patterns, sequences and aggregations.
     *   `Scheduler` drives time-based windows and cron style callbacks.
     *   `SiddhiAppRuntime` supports starting and shutting down applications and routes events through the configured processors.
-    *   Trigger runtimes are still TODO.
+    *   Triggers are executed via `TriggerRuntime`, allowing periodic or cron-based event generation.
     *   Error handling throughout `siddhi-core` remains basic.
 *   **Extensions Framework**:
     *   `ScalarFunctionExecutor` allows registering stateful user-defined functions.
@@ -155,6 +155,12 @@ Build and run with:
 
 ```bash
 cargo run --bin run_siddhi examples/sample.siddhi
+```
+
+To see trigger events in action you can run the trigger example:
+
+```bash
+cargo run --bin run_siddhi examples/trigger.siddhi
 ```
 
 All streams have a `LogSink` attached so events appear on stdout.

--- a/siddhi_rust/examples/run_sample.sh
+++ b/siddhi_rust/examples/run_sample.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
-# Run the example Siddhi app with the CLI
-cargo run --bin run_siddhi examples/sample.siddhi
+# Run a Siddhi app with the CLI. Pass the path to a .siddhi file or run the
+# basic sample if no argument is provided.
+
+APP_PATH=${1:-examples/sample.siddhi}
+cargo run --bin run_siddhi "$APP_PATH"

--- a/siddhi_rust/examples/trigger.siddhi
+++ b/siddhi_rust/examples/trigger.siddhi
@@ -1,0 +1,9 @@
+define trigger Tick at every 1 sec;
+
+-- Simple query logging each trigger event
+from Tick
+select triggered_time
+insert into OutStream;
+
+-- Output stream for logging
+define stream OutStream (triggered_time long);


### PR DESCRIPTION
## Summary
- add periodic and cron trigger runtime logic
- integrate triggers in SiddhiAppParser
- document how to run a simple trigger with a new example
- verify trigger event generation in `app_runner_triggers` tests

## Testing
- `cargo test --all -- --test-threads=1`


------
https://chatgpt.com/codex/tasks/task_e_6850e58d54588325bb80850259bb3973