### PR TITLE
Implement StreamEventFactory pooling and tests

### DIFF
--- a/siddhi_rust/src/core/event/stream/stream_event_cloner.rs
+++ b/siddhi_rust/src/core/event/stream/stream_event_cloner.rs
@@ -6,12 +6,27 @@ use super::{
     stream_event_factory::StreamEventFactory,
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct StreamEventCloner {
     before_window_data_size: usize,
     on_after_window_data_size: usize,
     output_data_size: usize,
     event_factory: StreamEventFactory,
+}
+
+impl Clone for StreamEventCloner {
+    fn clone(&self) -> Self {
+        Self {
+            before_window_data_size: self.before_window_data_size,
+            on_after_window_data_size: self.on_after_window_data_size,
+            output_data_size: self.output_data_size,
+            event_factory: StreamEventFactory::new(
+                self.before_window_data_size,
+                self.on_after_window_data_size,
+                self.output_data_size,
+            ),
+        }
+    }
 }
 
 impl StreamEventCloner {

--- a/siddhi_rust/src/core/event/stream/stream_event_factory.rs
+++ b/siddhi_rust/src/core/event/stream/stream_event_factory.rs
@@ -2,12 +2,16 @@
 // Corresponds to io.siddhi.core.event.stream.StreamEventFactory
 use super::meta_stream_event::MetaStreamEvent;
 use super::stream_event::StreamEvent;
+use crate::core::event::complex_event::ComplexEventType;
+use crate::core::event::value::AttributeValue;
+use std::sync::Mutex;
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct StreamEventFactory {
     pub before_window_data_size: usize,
     pub on_after_window_data_size: usize,
     pub output_data_size: usize,
+    pool: Mutex<Vec<StreamEvent>>,
 }
 
 impl StreamEventFactory {
@@ -20,6 +24,7 @@ impl StreamEventFactory {
             before_window_data_size,
             on_after_window_data_size,
             output_data_size,
+            pool: Mutex::new(Vec::new()),
         }
     }
 
@@ -28,15 +33,42 @@ impl StreamEventFactory {
             before_window_data_size: meta.get_before_window_data().len(),
             on_after_window_data_size: meta.get_on_after_window_data().len(),
             output_data_size: meta.get_output_data().len(),
+            pool: Mutex::new(Vec::new()),
         }
     }
 
     pub fn new_instance(&self) -> StreamEvent {
-        StreamEvent::new(
-            0,
-            self.before_window_data_size,
-            self.on_after_window_data_size,
-            self.output_data_size,
-        )
+        if let Some(mut ev) = self.pool.lock().unwrap().pop() {
+            ev.timestamp = 0;
+            ev.event_type = ComplexEventType::default();
+            for v in &mut ev.before_window_data {
+                *v = AttributeValue::default();
+            }
+            for v in &mut ev.on_after_window_data {
+                *v = AttributeValue::default();
+            }
+            if let Some(ref mut out) = ev.output_data {
+                for v in out {
+                    *v = AttributeValue::default();
+                }
+            }
+            ev.next = None;
+            ev
+        } else {
+            StreamEvent::new(
+                0,
+                self.before_window_data_size,
+                self.on_after_window_data_size,
+                self.output_data_size,
+            )
+        }
+    }
+
+    pub fn release(&self, event: StreamEvent) {
+        self.pool.lock().unwrap().push(event);
+    }
+
+    pub fn pool_size(&self) -> usize {
+        self.pool.lock().unwrap().len()
     }
 }


### PR DESCRIPTION
## Summary
- implement pooling in `StreamEventFactory`
- add manual `Clone` for `StreamEventCloner`
- use pooled events inside sequence and logical processors
- use pooled events for incremental executor and value store
- test pooled cloning behaviour in `event_chain_clone` test

## Testing
- `cargo test --manifest-path=siddhi_rust/Cargo.toml tests/event_chain_clone.rs`

------
https://chatgpt.com/codex/tasks/task_e_68523243d9188325a27c0fbdde269286