### PR TITLE
Enable snapshot state holders and persistence tests

### DIFF
--- a/siddhi_rust/src/core/util/mod.rs
+++ b/siddhi_rust/src/core/util/mod.rs
@@ -10,6 +10,7 @@ pub mod scheduled_executor_service;
 pub mod scheduler; // new scheduler module
 pub mod serialization;
 pub mod siddhi_constants; // Added siddhi_constants module
+pub mod state_holder;
 pub mod thread_barrier;
 // Potentially other existing util submodules:
 // pub mod cache;
@@ -36,3 +37,4 @@ pub use self::scheduler::{Schedulable, Scheduler};
 pub use self::serialization::{from_bytes, to_bytes};
 pub use self::siddhi_constants::SiddhiConstants; // Re-export SiddhiConstants
 pub use self::thread_barrier::ThreadBarrier;
+pub use self::state_holder::StateHolder;

--- a/siddhi_rust/src/core/util/state_holder.rs
+++ b/siddhi_rust/src/core/util/state_holder.rs
@@ -1,0 +1,9 @@
+use std::fmt::Debug;
+
+/// Trait representing a stateful component which can snapshot and restore its state.
+pub trait StateHolder: Send + Sync + Debug {
+    /// Serialize the current state of the component into bytes.
+    fn snapshot_state(&self) -> Vec<u8>;
+    /// Restore the component state from the given bytes.
+    fn restore_state(&self, snapshot: &[u8]);
+}


### PR DESCRIPTION
## Summary
- implement state holder trait
- wire up snapshot service to persist registered state holders
- allow SiddhiQueryContext to register state holders
- register a state holder in LengthWindowProcessor
- test persistence in `app_runner_persistence.rs`

## Testing
- `cargo test --test app_runner_persistence -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_68524acdcb4c8325ad1cdf66e708e859