### PR TITLE
Add extension factories and dynamic script traits

### DIFF
--- a/siddhi_rust/src/core/extension/mod.rs
+++ b/siddhi_rust/src/core/extension/mod.rs
@@ -2,6 +2,10 @@ use std::fmt::Debug;
 use std::sync::{Arc, Mutex};
 
 use crate::core::stream::output::stream_callback::StreamCallback;
+use crate::core::stream::input::mapper::SourceMapper;
+use crate::core::stream::output::mapper::SinkMapper;
+use crate::core::store::Store;
+use crate::core::function::script::Script;
 
 use crate::core::config::{
     siddhi_app_context::SiddhiAppContext, siddhi_query_context::SiddhiQueryContext,
@@ -62,6 +66,7 @@ impl Clone for Box<dyn SinkFactory> {
 
 pub trait StoreFactory: Debug + Send + Sync {
     fn name(&self) -> &'static str;
+    fn create(&self) -> Box<dyn Store>;
     fn clone_box(&self) -> Box<dyn StoreFactory>;
 }
 impl Clone for Box<dyn StoreFactory> {
@@ -72,6 +77,7 @@ impl Clone for Box<dyn StoreFactory> {
 
 pub trait SourceMapperFactory: Debug + Send + Sync {
     fn name(&self) -> &'static str;
+    fn create(&self) -> Box<dyn SourceMapper>;
     fn clone_box(&self) -> Box<dyn SourceMapperFactory>;
 }
 impl Clone for Box<dyn SourceMapperFactory> {
@@ -82,6 +88,7 @@ impl Clone for Box<dyn SourceMapperFactory> {
 
 pub trait SinkMapperFactory: Debug + Send + Sync {
     fn name(&self) -> &'static str;
+    fn create(&self) -> Box<dyn SinkMapper>;
     fn clone_box(&self) -> Box<dyn SinkMapperFactory>;
 }
 impl Clone for Box<dyn SinkMapperFactory> {
@@ -101,6 +108,17 @@ pub trait TableFactory: Debug + Send + Sync {
     fn clone_box(&self) -> Box<dyn TableFactory>;
 }
 impl Clone for Box<dyn TableFactory> {
+    fn clone(&self) -> Self {
+        self.clone_box()
+    }
+}
+
+pub trait ScriptFactory: Debug + Send + Sync {
+    fn name(&self) -> &'static str;
+    fn create(&self) -> Box<dyn Script>;
+    fn clone_box(&self) -> Box<dyn ScriptFactory>;
+}
+impl Clone for Box<dyn ScriptFactory> {
     fn clone(&self) -> Self {
         self.clone_box()
     }

--- a/siddhi_rust/src/core/function/mod.rs
+++ b/siddhi_rust/src/core/function/mod.rs
@@ -1,1 +1,4 @@
 
+pub mod script;
+
+pub use script::Script;

--- a/siddhi_rust/src/core/function/script.rs
+++ b/siddhi_rust/src/core/function/script.rs
@@ -1,0 +1,17 @@
+use crate::core::config::siddhi_app_context::SiddhiAppContext;
+use crate::core::event::complex_event::ComplexEvent;
+use crate::core::event::value::AttributeValue;
+use std::fmt::Debug;
+use std::sync::Arc;
+
+pub trait Script: Debug + Send + Sync {
+    fn init(&mut self, ctx: &Arc<SiddhiAppContext>) -> Result<(), String>;
+    fn eval(&self, event: Option<&dyn ComplexEvent>) -> Option<AttributeValue>;
+    fn clone_box(&self) -> Box<dyn Script>;
+}
+
+impl Clone for Box<dyn Script> {
+    fn clone(&self) -> Self {
+        self.clone_box()
+    }
+}

--- a/siddhi_rust/src/core/mod.rs
+++ b/siddhi_rust/src/core/mod.rs
@@ -14,6 +14,7 @@ pub mod exception; // For custom core-specific error types
 pub mod executor;
 pub mod extension;
 pub mod function; // For UDFs like Script.java
+pub mod store;
 pub mod partition;
 pub mod persistence; // Added
 pub mod query;

--- a/siddhi_rust/src/core/store.rs
+++ b/siddhi_rust/src/core/store.rs
@@ -1,0 +1,11 @@
+use std::fmt::Debug;
+
+pub trait Store: Debug + Send + Sync {
+    fn clone_box(&self) -> Box<dyn Store>;
+}
+
+impl Clone for Box<dyn Store> {
+    fn clone(&self) -> Self {
+        self.clone_box()
+    }
+}

--- a/siddhi_rust/src/core/stream/input/mapper.rs
+++ b/siddhi_rust/src/core/stream/input/mapper.rs
@@ -1,0 +1,13 @@
+use crate::core::event::event::Event;
+use std::fmt::Debug;
+
+pub trait SourceMapper: Debug + Send + Sync {
+    fn map(&self, input: &[u8]) -> Vec<Event>;
+    fn clone_box(&self) -> Box<dyn SourceMapper>;
+}
+
+impl Clone for Box<dyn SourceMapper> {
+    fn clone(&self) -> Self {
+        self.clone_box()
+    }
+}

--- a/siddhi_rust/src/core/stream/input/mod.rs
+++ b/siddhi_rust/src/core/stream/input/mod.rs
@@ -5,6 +5,7 @@ pub mod input_entry_valve;
 pub mod input_handler;
 pub mod input_manager;
 pub mod source;
+pub mod mapper;
 pub mod table_input_handler; // For sub-package source/
 
 pub use self::input_distributor::InputDistributor;
@@ -12,5 +13,6 @@ pub use self::input_entry_valve::InputEntryValve;
 pub use self::input_handler::InputHandler;
 pub use self::input_manager::InputManager;
 pub use self::table_input_handler::TableInputHandler;
+pub use self::mapper::SourceMapper;
 // pub use self::input_processor::InputProcessor; // If defined here
 // pub use self::table_input_handler::TableInputHandler;

--- a/siddhi_rust/src/core/stream/output/mapper.rs
+++ b/siddhi_rust/src/core/stream/output/mapper.rs
@@ -1,0 +1,13 @@
+use crate::core::event::event::Event;
+use std::fmt::Debug;
+
+pub trait SinkMapper: Debug + Send + Sync {
+    fn map(&self, events: &[Event]) -> Vec<u8>;
+    fn clone_box(&self) -> Box<dyn SinkMapper>;
+}
+
+impl Clone for Box<dyn SinkMapper> {
+    fn clone(&self) -> Self {
+        self.clone_box()
+    }
+}

--- a/siddhi_rust/src/core/stream/output/mod.rs
+++ b/siddhi_rust/src/core/stream/output/mod.rs
@@ -1,7 +1,9 @@
 // siddhi_rust/src/core/stream/output/mod.rs
 
 pub mod sink;
+pub mod mapper;
 pub mod stream_callback; // For sink implementations
 
 pub use self::sink::{LogSink, Sink};
+pub use self::mapper::SinkMapper;
 pub use self::stream_callback::{LogStreamCallback, StreamCallback};

--- a/siddhi_rust/tests/mapper.rs
+++ b/siddhi_rust/tests/mapper.rs
@@ -1,0 +1,75 @@
+#[path = "common/mod.rs"]
+mod common;
+use common::AppRunner;
+
+use siddhi_rust::core::event::event::Event;
+use siddhi_rust::core::event::value::AttributeValue;
+use siddhi_rust::core::stream::input::mapper::SourceMapper;
+use siddhi_rust::core::stream::output::mapper::SinkMapper;
+
+#[derive(Debug, Clone)]
+struct CsvSourceMapper;
+
+impl SourceMapper for CsvSourceMapper {
+    fn map(&self, input: &[u8]) -> Vec<Event> {
+        let text = std::str::from_utf8(input).unwrap();
+        text.lines()
+            .filter(|l| !l.trim().is_empty())
+            .map(|l| {
+                let values: Vec<AttributeValue> = l
+                    .split(',')
+                    .map(|p| AttributeValue::Int(p.trim().parse().unwrap()))
+                    .collect();
+                Event::new_with_data(0, values)
+            })
+            .collect()
+    }
+
+    fn clone_box(&self) -> Box<dyn SourceMapper> {
+        Box::new(self.clone())
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ConcatSinkMapper;
+
+impl SinkMapper for ConcatSinkMapper {
+    fn map(&self, events: &[Event]) -> Vec<u8> {
+        let mut parts = Vec::new();
+        for e in events {
+            for v in &e.data {
+                if let AttributeValue::Int(i) = v {
+                    parts.push(i.to_string());
+                }
+            }
+        }
+        parts.join(";").into_bytes()
+    }
+
+    fn clone_box(&self) -> Box<dyn SinkMapper> {
+        Box::new(self.clone())
+    }
+}
+
+#[test]
+fn test_source_and_sink_mapper_usage() {
+    let app = "\
+        define stream In (a int, b int);\n\
+        define stream Out (a int, b int);\n\
+        from In select a, b insert into Out;\n";
+    let runner = AppRunner::new(app, "Out");
+
+    let src_mapper = CsvSourceMapper;
+    let events = src_mapper.map(b"1,2\n3,4");
+    let data: Vec<Vec<AttributeValue>> = events.into_iter().map(|e| e.data).collect();
+    runner.send_batch("In", data);
+
+    let results = runner.shutdown();
+    let out_events: Vec<Event> = results
+        .iter()
+        .map(|row| Event::new_with_data(0, row.clone()))
+        .collect();
+    let sink_mapper = ConcatSinkMapper;
+    let bytes = sink_mapper.map(&out_events);
+    assert_eq!(bytes, b"1;2;3;4".to_vec());
+}


### PR DESCRIPTION
## Summary
- expose SourceMapper, SinkMapper, Store and Script traits
- implement factory traits for store/mapper/script extensions
- re-export new modules
- adjust dynamic extension integration test
- create a mapper integration test exercising SourceMapper/SinkMapper with AppRunner

## Testing
- `cargo test --test mapper -- --nocapture`
- `cargo test -- --test-threads=1`

------
https://chatgpt.com/codex/tasks/task_e_6852a62770dc8325985305d0d7360c79