### PR TITLE
Improve run_siddhi CLI and add sample Siddhi apps

### DIFF
--- a/siddhi_rust/Cargo.lock
+++ b/siddhi_rust/Cargo.lock
@@ -45,6 +45,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
 name = "ascii-canvas"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,6 +173,52 @@ dependencies = [
  "wasm-bindgen",
  "windows-link",
 ]
+
+[[package]]
+name = "clap"
+version = "4.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "core-foundation-sys"
@@ -313,6 +409,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,6 +453,12 @@ dependencies = [
  "equivalent",
  "hashbrown 0.15.3",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
@@ -513,6 +621,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "parking_lot"
@@ -786,6 +900,7 @@ version = "0.1.0"
 dependencies = [
  "bincode",
  "chrono",
+ "clap",
  "cron",
  "crossbeam-channel",
  "custom_dyn_ext",
@@ -826,6 +941,12 @@ dependencies = [
  "phf_shared",
  "precomputed-hash",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -902,6 +1023,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/siddhi_rust/Cargo.toml
+++ b/siddhi_rust/Cargo.toml
@@ -21,6 +21,7 @@ num_cpus = "1"
 once_cell = "1"
 rusqlite = { version = "0.29", features = ["bundled"] }
 libloading = "0.8"
+clap = { version = "4", features = ["derive"] }
 
 [build-dependencies]
 lalrpop = "0.20"

--- a/siddhi_rust/README.md
+++ b/siddhi_rust/README.md
@@ -163,7 +163,19 @@ To see trigger events in action you can run the trigger example:
 cargo run --bin run_siddhi examples/trigger.siddhi
 ```
 
-All streams have a `LogSink` attached so events appear on stdout.
+All streams have a `LogSink` attached so events appear on stdout. The CLI accepts
+some additional flags:
+
+```
+--persistence-dir <dir>   # enable file persistence
+--sqlite <db>             # use SQLite persistence
+--extension <lib>         # load a dynamic extension library (repeatable)
+--config <file>           # provide a custom configuration
+```
+
+Several example SiddhiQL files live in `examples/` including `simple_filter.siddhi`,
+`time_window.siddhi`, `partition.siddhi` and `extension.siddhi` mirroring the
+Java quick start samples.
 
 ## Next Planned Phases (High-Level)
 

--- a/siddhi_rust/examples/extension.siddhi
+++ b/siddhi_rust/examples/extension.siddhi
@@ -1,0 +1,5 @@
+define stream StockStream (symbol string, price long, volume long);
+@info(name = 'query1')
+from StockStream
+select symbol , custom:plus(price, volume) as totalCount
+insert into Output;

--- a/siddhi_rust/examples/partition.siddhi
+++ b/siddhi_rust/examples/partition.siddhi
@@ -1,0 +1,8 @@
+define stream StockStream (symbol string, price float,volume int);
+partition with (symbol of StockStream)
+begin
+   @info(name = 'query')
+   from StockStream#window.length(2)
+   select symbol, sum(price) as price, volume
+   insert into OutStockStream ;
+end

--- a/siddhi_rust/examples/simple_filter.siddhi
+++ b/siddhi_rust/examples/simple_filter.siddhi
@@ -1,0 +1,5 @@
+define stream StockStream (symbol string, price float, volume long);
+@info(name = 'query1')
+from StockStream[volume < 150]
+select symbol, price
+insert into OutputStream;

--- a/siddhi_rust/examples/time_window.siddhi
+++ b/siddhi_rust/examples/time_window.siddhi
@@ -1,0 +1,6 @@
+define stream StockEventStream (symbol string, price float, volume long);
+@info(name = 'query1')
+from StockEventStream#window.time(5 sec)
+select symbol, sum(price) as price, sum(volume) as volume
+group by symbol
+insert into AggregateStockStream;

--- a/siddhi_rust/src/bin/run_siddhi.rs
+++ b/siddhi_rust/src/bin/run_siddhi.rs
@@ -1,7 +1,9 @@
-use std::env;
 use std::fs;
+use std::path::PathBuf;
 use std::thread;
 use std::time::Duration;
+
+use clap::Parser;
 
 use siddhi_rust::core::persistence::{
     FilePersistenceStore, PersistenceStore, SqlitePersistenceStore,
@@ -10,38 +12,53 @@ use siddhi_rust::core::siddhi_manager::SiddhiManager;
 use siddhi_rust::core::stream::output::sink::LogSink;
 use std::sync::Arc;
 
-fn main() {
-    let args: Vec<String> = env::args().collect();
-    if args.len() < 2 {
-        eprintln!(
-            "Usage: {} <siddhi_file> [--store file:<dir>|sqlite:<file>]",
-            args[0]
-        );
-        std::process::exit(1);
-    }
+#[derive(Parser, Debug)]
+#[command(about = "Run a SiddhiQL file", author, version)]
+struct Cli {
+    /// SiddhiQL file to execute
+    siddhi_file: PathBuf,
 
-    let file = &args[1];
+    /// Directory for file based persistence snapshots
+    #[arg(long)]
+    persistence_dir: Option<PathBuf>,
+
+    /// Path to a SQLite DB file for persistence
+    #[arg(long)]
+    sqlite: Option<PathBuf>,
+
+    /// Dynamic extension libraries to load
+    #[arg(short = 'e', long)]
+    extension: Vec<PathBuf>,
+
+    /// Custom config file or identifier
+    #[arg(long)]
+    config: Option<String>,
+}
+
+fn main() {
+    let cli = Cli::parse();
+
     let mut store: Option<Arc<dyn PersistenceStore>> = None;
-    if args.len() >= 4 && args[2] == "--store" {
-        let spec = &args[3];
-        if let Some(path) = spec.strip_prefix("file:") {
-            match FilePersistenceStore::new(path) {
-                Ok(s) => store = Some(Arc::new(s)),
-                Err(e) => eprintln!("Failed to initialize file store: {}", e),
-            }
-        } else if let Some(path) = spec.strip_prefix("sqlite:") {
-            match SqlitePersistenceStore::new(path) {
-                Ok(s) => store = Some(Arc::new(s)),
-                Err(e) => eprintln!("Failed to initialize sqlite store: {}", e),
-            }
-        } else {
-            eprintln!("Unknown store specification '{}'", spec);
+    if let Some(dir) = cli.persistence_dir {
+        match FilePersistenceStore::new(dir.to_str().unwrap()) {
+            Ok(s) => store = Some(Arc::new(s)),
+            Err(e) => eprintln!("Failed to initialize file store: {}", e),
+        }
+    } else if let Some(db) = cli.sqlite {
+        match SqlitePersistenceStore::new(db.to_str().unwrap()) {
+            Ok(s) => store = Some(Arc::new(s)),
+            Err(e) => eprintln!("Failed to initialize sqlite store: {}", e),
         }
     }
-    let content = match fs::read_to_string(file) {
+
+    let content = match fs::read_to_string(&cli.siddhi_file) {
         Ok(c) => c,
         Err(e) => {
-            eprintln!("Failed to read {}: {}", file, e);
+            eprintln!(
+                "Failed to read {}: {}",
+                cli.siddhi_file.display(),
+                e
+            );
             std::process::exit(1);
         }
     };
@@ -49,6 +66,22 @@ fn main() {
     let manager = SiddhiManager::new();
     if let Some(s) = store {
         manager.set_persistence_store(s);
+    }
+    if let Some(cfg) = cli.config {
+        if let Err(e) = manager.set_config_manager(cfg) {
+            eprintln!("Failed to apply config: {}", e);
+        }
+    }
+    for lib in cli.extension {
+        if let Some(p) = lib.to_str() {
+            let name = lib
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("ext");
+            if let Err(e) = manager.set_extension(name, p.to_string()) {
+                eprintln!("Failed to load extension {}: {}", p, e);
+            }
+        }
     }
     let runtime = match manager.create_siddhi_app_runtime_from_string(&content) {
         Ok(rt) => rt,


### PR DESCRIPTION
## Summary
- extend run_siddhi binary with clap based flags for persistence, extensions, and custom configs
- add SiddhiQL examples mirroring Java quick start samples
- document new options in README

## Testing
- `cargo test --no-run`

------
https://chatgpt.com/codex/tasks/task_e_685394dd1c0883259812ba72b625254f