### PR TITLE
Enable async junction defaults and tests

### DIFF
--- a/siddhi_rust/src/core/README.md
+++ b/siddhi_rust/src/core/README.md
@@ -16,8 +16,3 @@ stateless query pipeline so the integration test in `src/lib.rs`
   (windows, tables, persistence, etc.).  Placeholders are provided where
   required by the API.
 
-## TODO
-
-* Implement proper `StreamEvent` factories and event pooling.
-* Flesh out the asynchronous path in `StreamJunction`.
-* Complete support for stateful processors and other execution types.

--- a/siddhi_rust/src/core/config/siddhi_app_context.rs
+++ b/siddhi_rust/src/core/config/siddhi_app_context.rs
@@ -149,6 +149,7 @@ impl SiddhiAppContext {
         siddhi_app_string: String,
     ) -> Self {
         // Default values from Java SiddhiAppContext() constructor and field initializers
+        let default_buffer = siddhi_context.get_default_junction_buffer_size() as i32;
         Self {
             siddhi_context,
             name,
@@ -170,7 +171,7 @@ impl SiddhiAppContext {
             // script_function_map: HashMap::new(),
             // disruptor_exception_handler: None, // Uses siddhiContext's default if not set
             // runtime_exception_listener: None,
-            buffer_size: 0, // Default not specified, using 0
+            buffer_size: default_buffer,
             // included_metrics: None,
             transport_channel_creation_enabled: false, // Default not specified, assuming false
             // scheduler_list: Vec::new(),

--- a/siddhi_rust/src/core/config/siddhi_context.rs
+++ b/siddhi_rust/src/core/config/siddhi_context.rs
@@ -72,6 +72,12 @@ pub struct SiddhiContext {
     record_table_handler_manager: Option<RecordTableHandlerManagerPlaceholder>,
     default_disrupter_exception_handler: DisruptorExceptionHandlerPlaceholder,
 
+    /// Default buffer size for StreamJunctions created when parsing Siddhi apps.
+    default_junction_buffer_size: usize,
+    /// Whether StreamJunctions should run asynchronously by default when no
+    /// annotation overrides the mode.
+    default_junction_async: bool,
+
     // Actual fields for extensions and data sources
     /// Stores factories for User-Defined Scalar Functions. Key: "namespace:name" or "name", Value: clonable factory instance.
     scalar_function_factories: Arc<RwLock<HashMap<String, Box<dyn ScalarFunctionExecutor>>>>,
@@ -133,6 +139,8 @@ impl SiddhiContext {
             source_handler_manager: None,
             record_table_handler_manager: None,
             default_disrupter_exception_handler: "DefaultDisruptorExceptionHandler".to_string(),
+            default_junction_buffer_size: 1024,
+            default_junction_async: false,
             dummy_field_siddhi_context_extensions: String::new(),
         };
         ctx.register_default_extensions();
@@ -273,6 +281,22 @@ impl SiddhiContext {
 
     pub fn get_default_disruptor_exception_handler(&self) -> &String {
         &self.default_disrupter_exception_handler
+    }
+
+    pub fn get_default_junction_buffer_size(&self) -> usize {
+        self.default_junction_buffer_size
+    }
+
+    pub fn set_default_junction_buffer_size(&mut self, size: usize) {
+        self.default_junction_buffer_size = size;
+    }
+
+    pub fn get_default_async_mode(&self) -> bool {
+        self.default_junction_async
+    }
+
+    pub fn set_default_async_mode(&mut self, mode: bool) {
+        self.default_junction_async = mode;
     }
 
     pub fn get_attributes(
@@ -552,6 +576,8 @@ impl Clone for SiddhiContext {
             source_handler_manager: self.source_handler_manager.clone(),
             record_table_handler_manager: self.record_table_handler_manager.clone(),
             default_disrupter_exception_handler: self.default_disrupter_exception_handler.clone(),
+            default_junction_buffer_size: self.default_junction_buffer_size,
+            default_junction_async: self.default_junction_async,
             dummy_field_siddhi_context_extensions: self
                 .dummy_field_siddhi_context_extensions
                 .clone(),

--- a/siddhi_rust/src/core/util/parser/siddhi_app_parser.rs
+++ b/siddhi_rust/src/core/util/parser/siddhi_app_parser.rs
@@ -35,7 +35,9 @@ impl SiddhiAppParser {
         let mut builder = SiddhiAppRuntimeBuilder::new(siddhi_app_context.clone());
 
         // Parse @app level annotations to configure defaults
-        let mut default_stream_async = false;
+        let mut default_stream_async = siddhi_app_context
+            .get_siddhi_context()
+            .get_default_async_mode();
         for ann in &api_siddhi_app.annotations {
             if ann.name.eq_ignore_ascii_case("app") {
                 for el in &ann.elements {

--- a/siddhi_rust/tests/app_runner_async_junction.rs
+++ b/siddhi_rust/tests/app_runner_async_junction.rs
@@ -1,0 +1,32 @@
+#[path = "common/mod.rs"]
+mod common;
+use common::AppRunner;
+use siddhi_rust::core::event::value::AttributeValue;
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn async_junction_concurrent_dispatch() {
+    let app = "@app:async('true')\n\
+        define stream In (v int);\n\
+        define stream Out (v int);\n\
+        from In select v insert into Out;\n";
+    let runner = Arc::new(AppRunner::new(app, "Out"));
+    let mut handles = Vec::new();
+    for i in 0..4 {
+        let r = Arc::clone(&runner);
+        handles.push(thread::spawn(move || {
+            for k in 0..500 {
+                r.send("In", vec![AttributeValue::Int(i * 500 + k)]);
+            }
+        }));
+    }
+    for h in handles {
+        h.join().unwrap();
+    }
+    thread::sleep(Duration::from_millis(300));
+    let runner = Arc::try_unwrap(runner).unwrap();
+    let out = runner.shutdown();
+    assert_eq!(out.len(), 2000);
+}


### PR DESCRIPTION
## Summary
- configure default junction buffer size and mode in SiddhiContext
- pass defaults into SiddhiAppContext and parser
- add AppRunner test for async dispatch
- clean up TODO list in README

## Testing
- `cargo test --workspace --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6857fc34e0808325b4d60b55759c3849