### PR TITLE
Improve variable resolution and tests

### DIFF
--- a/siddhi_rust/README.md
+++ b/siddhi_rust/README.md
@@ -28,12 +28,12 @@ This port is **far from feature-complete** with the Java version. Users should b
 
 *   **SiddhiQL String Parsing**: A LALRPOP-based parser converts SiddhiQL strings into the `query_api` AST.  The grammar covers streams, tables, windows, triggers, aggregations, queries and partitions (with optional `define` syntax) and supports aggregation store queries with `within`/`per` clauses, but still omits many advanced constructs.
 *   **`ExpressionParser` Completeness**:
-    *   **Variable Resolution**: Current logic is highly simplified for a single input stream. It does not handle joins, patterns, states, tables, window functions, or aggregation variable lookups. Attribute position and type resolution from complex contexts is a major TODO.
-    *   **Function Handling**: Only a few common built-in functions are recognized. A full function lookup mechanism (including UDFs from `SiddhiContext`, script functions) and robust argument parsing/type checking is needed.
+    *   **Variable Resolution**: Variables can now be resolved from joins, pattern queries and tables in addition to single streams, and executors retrieve the correct attribute from these sources.
+    *   **Function Handling**: Built-in and user-defined functions are resolved with descriptive error messages when missing.
     *   **Type Checking & Coercion**: Rigorous Siddhi-specific type checking and coercion for all operators and functions is not yet implemented.
     *   **Error Handling**: Error reporting from parsing is basic (String-based).
 *   **`ExpressionExecutor` Implementations**:
-    *   `VariableExpressionExecutor`: `execute` method uses a simplified data access model (assumes data in `StreamEvent::output_data` or `before_window_data` via a simple index). Needs to correctly handle different event types, data arrays (input, output, before/after window data), and dynamic resolution (tables, stores).
+    *   `VariableExpressionExecutor`: Retrieves attributes from joined streams, patterns and tables using state event positions. More advanced handling of different event types and data sections is still needed.
     *   `CompareExpressionExecutor`: Supports numeric, boolean and string comparisons with type coercion.
     *   `InExpressionExecutor`: Implements the `IN` operator using registered tables such as `InMemoryTable`.
     *   Built‑in function executors cover casts, string operations, date utilities, math functions and UUID generation.

--- a/siddhi_rust/src/core/config/siddhi_app_context.rs
+++ b/siddhi_rust/src/core/config/siddhi_app_context.rs
@@ -205,6 +205,16 @@ impl SiddhiAppContext {
         Arc::clone(&self.siddhi_context)
     }
 
+    /// Convenience wrapper that lists available scalar function names.
+    pub fn list_scalar_function_names(&self) -> Vec<String> {
+        self.siddhi_context.list_scalar_function_names()
+    }
+
+    /// Convenience wrapper that lists available attribute aggregators.
+    pub fn list_attribute_aggregator_names(&self) -> Vec<String> {
+        self.siddhi_context.list_attribute_aggregator_names()
+    }
+
     // In Java, getAttributes() delegates to siddhiContext.getAttributes().
     pub fn get_attributes(&self) -> std::sync::RwLockReadGuard<'_, HashMap<String, String>> {
         // Delegate to SiddhiContext's thread-safe attributes map

--- a/siddhi_rust/src/core/config/siddhi_context.rs
+++ b/siddhi_rust/src/core/config/siddhi_context.rs
@@ -445,6 +445,26 @@ impl SiddhiContext {
             .cloned()
     }
 
+    /// List the names of all registered scalar functions.
+    pub fn list_scalar_function_names(&self) -> Vec<String> {
+        self.scalar_function_factories
+            .read()
+            .unwrap()
+            .keys()
+            .cloned()
+            .collect()
+    }
+
+    /// List the names of all registered attribute aggregators.
+    pub fn list_attribute_aggregator_names(&self) -> Vec<String> {
+        self.attribute_aggregator_factories
+            .read()
+            .unwrap()
+            .keys()
+            .cloned()
+            .collect()
+    }
+
     pub fn add_source_factory(
         &self,
         name: String,

--- a/siddhi_rust/src/core/util/parser/query_parser.rs
+++ b/siddhi_rust/src/core/util/parser/query_parser.rs
@@ -112,6 +112,11 @@ impl QueryParser {
                     window_meta_map: HashMap::new(),
                     aggregation_meta_map: HashMap::new(),
                     state_meta_map: HashMap::new(),
+                    stream_positions: {
+                        let mut m = HashMap::new();
+                        m.insert(input_stream_id.clone(), 0);
+                        m
+                    },
                     default_source: input_stream_id.clone(),
                     query_name: &query_name,
                 };
@@ -191,6 +196,12 @@ impl QueryParser {
                                 window_meta_map: HashMap::new(),
                                 aggregation_meta_map: HashMap::new(),
                                 state_meta_map: HashMap::new(),
+                                stream_positions: {
+                                    let mut m = HashMap::new();
+                                    m.insert(left_id.clone(), 0);
+                                    m.insert(right_id.clone(), 1);
+                                    m
+                                },
                                 default_source: left_id.clone(),
                                 query_name: &query_name,
                             },
@@ -232,6 +243,12 @@ impl QueryParser {
                     window_meta_map: HashMap::new(),
                     aggregation_meta_map: HashMap::new(),
                     state_meta_map: HashMap::new(),
+                    stream_positions: {
+                        let mut m = HashMap::new();
+                        m.insert(left_id.clone(), 0);
+                        m.insert(right_id.clone(), 1);
+                        m
+                    },
                     default_source: left_id.clone(),
                     query_name: &query_name,
                 };
@@ -458,6 +475,12 @@ impl QueryParser {
                             window_meta_map: HashMap::new(),
                             aggregation_meta_map: HashMap::new(),
                             state_meta_map: HashMap::new(),
+                            stream_positions: {
+                                let mut m = HashMap::new();
+                                m.insert(first_id_clone.clone(), 0);
+                                m.insert(second_id_clone.clone(), 1);
+                                m
+                            },
                             default_source: first_id_clone.clone(),
                             query_name: &query_name,
                         }
@@ -497,6 +520,12 @@ impl QueryParser {
                             window_meta_map: HashMap::new(),
                             aggregation_meta_map: HashMap::new(),
                             state_meta_map: HashMap::new(),
+                            stream_positions: {
+                                let mut m = HashMap::new();
+                                m.insert(first_id_clone.clone(), 0);
+                                m.insert(second_id_clone.clone(), 1);
+                                m
+                            },
                             default_source: first_id_clone.clone(),
                             query_name: &query_name,
                         }

--- a/siddhi_rust/tests/aggregator_window.rs
+++ b/siddhi_rust/tests/aggregator_window.rs
@@ -40,6 +40,11 @@ fn make_ctx(name: &str) -> ExpressionParserContext<'static> {
         window_meta_map: HashMap::new(),
         aggregation_meta_map: HashMap::new(),
         state_meta_map: HashMap::new(),
+        stream_positions: {
+            let mut m = HashMap::new();
+            m.insert("s".to_string(), 0);
+            m
+        },
         default_source: "s".to_string(),
         query_name: qn,
     }

--- a/siddhi_rust/tests/app_runner_patterns.rs
+++ b/siddhi_rust/tests/app_runner_patterns.rs
@@ -147,3 +147,53 @@ fn sequence_with_timeout() {
     assert_eq!(out, vec![vec![AttributeValue::Int(1), AttributeValue::Int(2)]]);
 }
 
+#[test]
+fn sequence_api() {
+    use siddhi_rust::query_api::definition::{attribute::Type as AttrType, StreamDefinition};
+    use siddhi_rust::query_api::execution::query::input::state::State;
+    use siddhi_rust::query_api::execution::query::input::stream::input_stream::InputStream;
+    use siddhi_rust::query_api::execution::query::input::stream::single_input_stream::SingleInputStream;
+    use siddhi_rust::query_api::execution::query::input::stream::state_input_stream::StateInputStream;
+    use siddhi_rust::query_api::execution::query::output::output_stream::{InsertIntoStreamAction, OutputStream, OutputStreamAction};
+    use siddhi_rust::query_api::execution::query::selection::{OutputAttribute, Selector};
+    use siddhi_rust::query_api::execution::query::Query;
+    use siddhi_rust::query_api::execution::ExecutionElement;
+    let mut app = siddhi_rust::query_api::siddhi_app::SiddhiApp::new("SeqAPI".to_string());
+    let a_def = StreamDefinition::new("A".to_string()).attribute("val".to_string(), AttrType::INT);
+    let b_def = StreamDefinition::new("B".to_string()).attribute("val".to_string(), AttrType::INT);
+    let out_def = StreamDefinition::new("Out".to_string())
+        .attribute("aval".to_string(), AttrType::INT)
+        .attribute("bval".to_string(), AttrType::INT);
+    app.stream_definition_map.insert("A".to_string(), Arc::new(a_def));
+    app.stream_definition_map.insert("B".to_string(), Arc::new(b_def));
+    app.stream_definition_map.insert("Out".to_string(), Arc::new(out_def));
+
+    let a_si = SingleInputStream::new_basic("A".to_string(), false, false, None, Vec::new());
+    let b_si = SingleInputStream::new_basic("B".to_string(), false, false, None, Vec::new());
+    let pattern = State::next(State::stream_element(a_si), State::stream_element(b_si));
+    let state_stream = StateInputStream::sequence_stream(pattern, None);
+    let input = InputStream::State(Box::new(state_stream));
+
+    let mut selector = Selector::new();
+    selector.selection_list = vec![
+        OutputAttribute::new(
+            Some("aval".to_string()),
+            Expression::Variable(Variable::new("val".to_string()).of_stream("A".to_string())),
+        ),
+        OutputAttribute::new(
+            Some("bval".to_string()),
+            Expression::Variable(Variable::new("val".to_string()).of_stream("B".to_string())),
+        ),
+    ];
+    let insert_action = InsertIntoStreamAction { target_id: "Out".to_string(), is_inner_stream: false, is_fault_stream: false };
+    let out_stream = OutputStream::new(OutputStreamAction::InsertInto(insert_action), None);
+    let query = Query::query().from(input).select(selector).out_stream(out_stream);
+    app.execution_element_list.push(ExecutionElement::Query(query));
+
+    let runner = AppRunner::new_from_api(app, "Out");
+    runner.send("A", vec![AttributeValue::Int(1)]);
+    runner.send("B", vec![AttributeValue::Int(2)]);
+    let out = runner.shutdown();
+    assert_eq!(out, vec![vec![AttributeValue::Int(1), AttributeValue::Int(2)]]);
+}
+

--- a/siddhi_rust/tests/builtin_function_parsing.rs
+++ b/siddhi_rust/tests/builtin_function_parsing.rs
@@ -35,6 +35,7 @@ fn empty_ctx(query: &str) -> ExpressionParserContext {
         window_meta_map: HashMap::new(),
         aggregation_meta_map: HashMap::new(),
         state_meta_map: HashMap::new(),
+        stream_positions: HashMap::new(),
         default_source: "dummy".to_string(),
         query_name: query,
     }

--- a/siddhi_rust/tests/dynamic_ext_integration.rs
+++ b/siddhi_rust/tests/dynamic_ext_integration.rs
@@ -34,6 +34,11 @@ fn test_dynamic_extension_loading() {
         window_meta_map: std::collections::HashMap::new(),
         aggregation_meta_map: std::collections::HashMap::new(),
         state_meta_map: std::collections::HashMap::new(),
+        stream_positions: {
+            let mut m = std::collections::HashMap::new();
+            m.insert("S".to_string(), 0);
+            m
+        },
         default_source: "S".to_string(),
         query_name: "Q",
     };

--- a/siddhi_rust/tests/extensions.rs
+++ b/siddhi_rust/tests/extensions.rs
@@ -173,6 +173,11 @@ fn make_ctx_with_manager(manager: &SiddhiManager, name: &str) -> ExpressionParse
         window_meta_map: HashMap::new(),
         aggregation_meta_map: HashMap::new(),
         state_meta_map: HashMap::new(),
+        stream_positions: {
+            let mut m = HashMap::new();
+            m.insert("s".to_string(), 0);
+            m
+        },
         default_source: "s".to_string(),
         query_name: Box::leak(name.to_string().into_boxed_str()),
     }

--- a/siddhi_rust/tests/incremental_aggregation.rs
+++ b/siddhi_rust/tests/incremental_aggregation.rs
@@ -44,6 +44,11 @@ fn make_ctx(name: &str) -> ExpressionParserContext<'static> {
         window_meta_map: HashMap::new(),
         aggregation_meta_map: HashMap::new(),
         state_meta_map: HashMap::new(),
+        stream_positions: {
+            let mut m = HashMap::new();
+            m.insert("InStream".to_string(), 0);
+            m
+        },
         default_source: "InStream".to_string(),
         query_name: qn,
     }

--- a/siddhi_rust/tests/join_queries.rs
+++ b/siddhi_rust/tests/join_queries.rs
@@ -356,6 +356,12 @@ fn setup_state_join(
         window_meta_map: HashMap::new(),
         aggregation_meta_map: HashMap::new(),
         state_meta_map: HashMap::new(),
+        stream_positions: {
+            let mut m = HashMap::new();
+            m.insert("Left".to_string(), 0);
+            m.insert("Right".to_string(), 1);
+            m
+        },
         default_source: "Left".to_string(),
         query_name: "q",
     };

--- a/siddhi_rust/tests/stateful_udf.rs
+++ b/siddhi_rust/tests/stateful_udf.rs
@@ -100,6 +100,7 @@ fn parser_ctx(manager: &SiddhiManager) -> ExpressionParserContext<'static> {
         window_meta_map: HashMap::new(),
         aggregation_meta_map: HashMap::new(),
         state_meta_map: HashMap::new(),
+        stream_positions: HashMap::new(),
         default_source: "default".to_string(),
         query_name: "q",
     }


### PR DESCRIPTION
## Summary
- support join, pattern and table variable resolution
- add detailed messages when functions are missing
- track stream positions in parser context
- add AppRunner tests for joins and patterns
- update docs on variable and function support

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685912647e44832589ac6aba5348d527