### PR TITLE
Add Cron and LossyCounting windows

### DIFF
--- a/siddhi_rust/src/core/config/siddhi_context.rs
+++ b/siddhi_rust/src/core/config/siddhi_context.rs
@@ -339,8 +339,9 @@ impl SiddhiContext {
         use crate::core::executor::function::builtin_wrapper::register_builtin_scalar_functions;
         use crate::core::extension::{LogSinkFactory, TimerSourceFactory};
         use crate::core::query::processor::stream::window::{
-            ExternalTimeBatchWindowFactory, ExternalTimeWindowFactory, LengthBatchWindowFactory,
-            LengthWindowFactory, TimeBatchWindowFactory, TimeWindowFactory,
+            CronWindowFactory, ExternalTimeBatchWindowFactory, ExternalTimeWindowFactory,
+            LengthBatchWindowFactory, LengthWindowFactory, LossyCountingWindowFactory,
+            TimeBatchWindowFactory, TimeWindowFactory,
         };
         use crate::core::query::selector::attribute::aggregator::{
             AvgAttributeAggregatorFactory, CountAttributeAggregatorFactory,
@@ -365,6 +366,8 @@ impl SiddhiContext {
             "externalTimeBatch".to_string(),
             Box::new(ExternalTimeBatchWindowFactory),
         );
+        self.add_window_factory("lossyCounting".to_string(), Box::new(LossyCountingWindowFactory));
+        self.add_window_factory("cron".to_string(), Box::new(CronWindowFactory));
 
         self.add_attribute_aggregator_factory(
             "sum".to_string(),


### PR DESCRIPTION
## Summary
- add new CronWindowProcessor and LossyCountingWindowProcessor
- expose factories for the new windows
- register them in SiddhiContext
- add tests for cron and lossy counting windows

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685a7a7d13b88325a0428dbb1d2f5ff8