### PR TITLE
Add rate limiter flush and snapshot helpers

### DIFF
--- a/siddhi_rust/src/core/siddhi_app_runtime.rs
+++ b/siddhi_rust/src/core/siddhi_app_runtime.rs
@@ -203,6 +203,9 @@ impl SiddhiAppRuntime {
         for pr in &self.partition_runtimes {
             pr.shutdown();
         }
+        for qr in &self.query_runtimes {
+            qr.flush();
+        }
         if let Some(service) = self.siddhi_app_context.get_snapshot_service() {
             if let Some(store) = &service.persistence_store {
                 store.clear_all_revisions(&self.name);
@@ -218,6 +221,25 @@ impl SiddhiAppRuntime {
             .get_snapshot_service()
             .ok_or("SnapshotService not set")?;
         service.persist()
+    }
+
+    /// Capture a snapshot of the current state via the SnapshotService.
+    pub fn snapshot(&self) -> Result<Vec<u8>, String> {
+        let service = self
+            .siddhi_app_context
+            .get_snapshot_service()
+            .ok_or("SnapshotService not set")?;
+        Ok(service.snapshot())
+    }
+
+    /// Restore the given snapshot bytes using the SnapshotService.
+    pub fn restore(&self, snapshot: &[u8]) -> Result<(), String> {
+        let service = self
+            .siddhi_app_context
+            .get_snapshot_service()
+            .ok_or("SnapshotService not set")?;
+        service.set_state(snapshot.to_vec());
+        Ok(())
     }
 
     /// Restore the given revision using the SnapshotService.

--- a/siddhi_rust/tests/app_runner_output_rate.rs
+++ b/siddhi_rust/tests/app_runner_output_rate.rs
@@ -1,0 +1,61 @@
+#[path = "common/mod.rs"]
+mod common;
+use common::AppRunner;
+use siddhi_rust::core::event::value::AttributeValue;
+use siddhi_rust::core::persistence::{InMemoryPersistenceStore, PersistenceStore};
+use siddhi_rust::query_api::definition::{attribute::Type as AttrType, StreamDefinition};
+use siddhi_rust::query_api::execution::query::input::InputStream;
+use siddhi_rust::query_api::execution::query::output::output_stream::{InsertIntoStreamAction, OutputStream, OutputStreamAction};
+use siddhi_rust::query_api::execution::query::output::ratelimit::{OutputRate, OutputRateBehavior};
+use siddhi_rust::query_api::execution::query::selection::Selector;
+use siddhi_rust::query_api::execution::query::Query;
+use siddhi_rust::query_api::execution::ExecutionElement;
+use siddhi_rust::query_api::expression::{constant::Constant, variable::Variable};
+use siddhi_rust::query_api::siddhi_app::SiddhiApp;
+use std::sync::Arc;
+
+fn make_app() -> SiddhiApp {
+    let mut app = SiddhiApp::new("RateApp".to_string());
+    app.add_stream_definition(StreamDefinition::new("In".to_string()).attribute("v".to_string(), AttrType::INT));
+    app.add_stream_definition(StreamDefinition::new("Out".to_string()).attribute("v".to_string(), AttrType::INT));
+    let input = InputStream::stream("In".to_string());
+    let selector = Selector::new().select_variable(Variable::new("v".to_string()));
+    let out_action = InsertIntoStreamAction { target_id: "Out".to_string(), is_inner_stream: false, is_fault_stream: false };
+    let out_stream = OutputStream::new(OutputStreamAction::InsertInto(out_action), None);
+    let rate = OutputRate::per_events(Constant::int(2), OutputRateBehavior::All).unwrap();
+    let query = Query::query().from(input).select(selector).out_stream(out_stream).output(rate);
+    app.add_execution_element(ExecutionElement::Query(query));
+    app
+}
+
+#[test]
+fn rate_limit_emits_in_batches() {
+    let app = make_app();
+    let runner = AppRunner::new_from_api(app, "Out");
+    runner.send("In", vec![AttributeValue::Int(1)]);
+    assert_eq!(runner.collected.lock().unwrap().len(), 0);
+    runner.send("In", vec![AttributeValue::Int(2)]);
+    assert_eq!(runner.collected.lock().unwrap().len(), 2);
+    runner.send("In", vec![AttributeValue::Int(3)]);
+    assert_eq!(runner.collected.lock().unwrap().len(), 2);
+    runner.send("In", vec![AttributeValue::Int(4)]);
+    assert_eq!(runner.collected.lock().unwrap().len(), 4);
+    let out = runner.shutdown();
+    assert_eq!(out.len(), 4);
+}
+
+#[test]
+fn rate_limit_persist_restore() {
+    let store: Arc<dyn PersistenceStore> = Arc::new(InMemoryPersistenceStore::new());
+    let app = make_app();
+    let runner = AppRunner::new_from_api_with_store(app, "Out", Arc::clone(&store));
+    runner.send("In", vec![AttributeValue::Int(1)]);
+    let rev = runner.persist();
+    runner.send("In", vec![AttributeValue::Int(2)]);
+    assert_eq!(runner.collected.lock().unwrap().len(), 2);
+    runner.restore_revision(&rev);
+    runner.send("In", vec![AttributeValue::Int(3)]);
+    runner.send("In", vec![AttributeValue::Int(4)]);
+    let out = runner.shutdown();
+    assert_eq!(out.len(), 5);
+}


### PR DESCRIPTION
## Summary
- implement buffer flushing in `OutputRateLimiter` including drop handling
- add `flush` method on `QueryRuntime` and invoke it at runtime shutdown
- expose throttled output test using new flush logic
- remove obsolete TODOs

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685b66c5c00c8325b9f1217ad7ab8b0f