### PR TITLE
Add CacheTable

### DIFF
--- a/siddhi_rust/src/core/config/siddhi_context.rs
+++ b/siddhi_rust/src/core/config/siddhi_context.rs
@@ -349,7 +349,7 @@ impl SiddhiContext {
             MaxForeverAttributeAggregatorFactory, MinAttributeAggregatorFactory,
             MinForeverAttributeAggregatorFactory, SumAttributeAggregatorFactory,
         };
-        use crate::core::table::{InMemoryTableFactory, JdbcTableFactory};
+        use crate::core::table::{CacheTableFactory, InMemoryTableFactory, JdbcTableFactory};
 
         self.add_window_factory("length".to_string(), Box::new(LengthWindowFactory));
         self.add_window_factory("time".to_string(), Box::new(TimeWindowFactory));
@@ -404,6 +404,7 @@ impl SiddhiContext {
 
         self.add_table_factory("inMemory".to_string(), Box::new(InMemoryTableFactory));
         self.add_table_factory("jdbc".to_string(), Box::new(JdbcTableFactory));
+        self.add_table_factory("cache".to_string(), Box::new(CacheTableFactory));
         self.add_source_factory("timer".to_string(), Box::new(TimerSourceFactory));
         self.add_sink_factory("log".to_string(), Box::new(LogSinkFactory));
 

--- a/siddhi_rust/src/core/table/cache_table.rs
+++ b/siddhi_rust/src/core/table/cache_table.rs
@@ -1,0 +1,112 @@
+use crate::core::config::siddhi_context::SiddhiContext;
+use crate::core::event::value::AttributeValue;
+use crate::core::extension::TableFactory;
+use crate::core::table::Table;
+use std::collections::{HashMap, VecDeque};
+use std::fmt::Debug;
+use std::sync::{Arc, RwLock};
+
+#[derive(Debug)]
+pub struct CacheTable {
+    rows: RwLock<VecDeque<Vec<AttributeValue>>>,
+    max_size: usize,
+}
+
+impl CacheTable {
+    pub fn new(max_size: usize) -> Self {
+        Self {
+            rows: RwLock::new(VecDeque::new()),
+            max_size,
+        }
+    }
+
+    fn trim_if_needed(&self, rows: &mut VecDeque<Vec<AttributeValue>>) {
+        while rows.len() > self.max_size {
+            rows.pop_front();
+        }
+    }
+
+    /// Helper for tests to access all rows
+    #[allow(dead_code)]
+    pub fn all_rows(&self) -> Vec<Vec<AttributeValue>> {
+        self.rows.read().unwrap().iter().cloned().collect()
+    }
+}
+
+impl Table for CacheTable {
+    fn insert(&self, values: &[AttributeValue]) {
+        let mut rows = self.rows.write().unwrap();
+        rows.push_back(values.to_vec());
+        self.trim_if_needed(&mut rows);
+    }
+
+    fn update(&self, old_values: &[AttributeValue], new_values: &[AttributeValue]) -> bool {
+        let mut rows = self.rows.write().unwrap();
+        let mut updated = false;
+        for row in rows.iter_mut() {
+            if row.as_slice() == old_values {
+                *row = new_values.to_vec();
+                updated = true;
+            }
+        }
+        updated
+    }
+
+    fn delete(&self, values: &[AttributeValue]) -> bool {
+        let mut rows = self.rows.write().unwrap();
+        let orig_len = rows.len();
+        rows.retain(|row| row.as_slice() != values);
+        orig_len != rows.len()
+    }
+
+    fn find(&self, values: &[AttributeValue]) -> Option<Vec<AttributeValue>> {
+        self
+            .rows
+            .read()
+            .unwrap()
+            .iter()
+            .find(|row| row.as_slice() == values)
+            .cloned()
+    }
+
+    fn contains(&self, values: &[AttributeValue]) -> bool {
+        self.rows.read().unwrap().iter().any(|row| row == values)
+    }
+
+    fn clone_table(&self) -> Box<dyn Table> {
+        let rows = self.rows.read().unwrap().clone();
+        Box::new(CacheTable {
+            rows: RwLock::new(rows),
+            max_size: self.max_size,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CacheTableFactory;
+
+impl TableFactory for CacheTableFactory {
+    fn name(&self) -> &'static str {
+        "cache"
+    }
+
+    fn create(
+        &self,
+        _name: String,
+        mut properties: HashMap<String, String>,
+        _ctx: Arc<SiddhiContext>,
+    ) -> Result<Arc<dyn Table>, String> {
+        let size_str = properties
+            .remove("max_size")
+            .ok_or_else(|| "max_size property required".to_string())?;
+        let size = size_str
+            .parse::<usize>()
+            .map_err(|_| "max_size must be a number".to_string())?;
+        Ok(Arc::new(CacheTable::new(size)))
+    }
+
+    fn clone_box(&self) -> Box<dyn TableFactory> {
+        Box::new(self.clone())
+    }
+}
+

--- a/siddhi_rust/src/core/table/mod.rs
+++ b/siddhi_rust/src/core/table/mod.rs
@@ -2,9 +2,11 @@ use crate::core::event::value::AttributeValue;
 use std::sync::RwLock;
 
 mod jdbc_table;
+mod cache_table;
 use crate::core::config::siddhi_context::SiddhiContext;
 use crate::core::extension::TableFactory;
 pub use jdbc_table::{JdbcTable, JdbcTableFactory};
+pub use cache_table::{CacheTable, CacheTableFactory};
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::sync::Arc;

--- a/siddhi_rust/tests/cache_table.rs
+++ b/siddhi_rust/tests/cache_table.rs
@@ -1,0 +1,31 @@
+use siddhi_rust::core::event::value::AttributeValue;
+use siddhi_rust::core::table::{CacheTable, Table};
+
+#[test]
+fn test_cache_insert_and_eviction() {
+    let table = CacheTable::new(2);
+    let r1 = vec![AttributeValue::Int(1)];
+    let r2 = vec![AttributeValue::Int(2)];
+    let r3 = vec![AttributeValue::Int(3)];
+    table.insert(&r1);
+    table.insert(&r2);
+    table.insert(&r3);
+    // r1 should be evicted
+    assert!(!table.contains(&r1));
+    assert!(table.contains(&r2));
+    assert!(table.contains(&r3));
+}
+
+#[test]
+fn test_cache_update_delete_find() {
+    let table = CacheTable::new(3);
+    let r1 = vec![AttributeValue::Int(1)];
+    table.insert(&r1);
+    let r2 = vec![AttributeValue::Int(2)];
+    assert!(table.update(&r1, &r2));
+    assert!(!table.contains(&r1));
+    assert!(table.contains(&r2));
+    assert_eq!(table.find(&r2), Some(r2.clone()));
+    assert!(table.delete(&r2));
+    assert!(table.find(&r2).is_none());
+}


### PR DESCRIPTION
## Summary
- implement `CacheTable` with FIFO eviction
- register `CacheTableFactory` within `SiddhiContext`
- test cache table behaviour
- verify lookup in cache table tests

## Testing
- `cargo test --no-run`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_685e1334caf883258d1be9d189c8d551