### PR TITLE
Add table compilation marker traits

### DIFF
--- a/siddhi_rust/src/core/table/cache_table.rs
+++ b/siddhi_rust/src/core/table/cache_table.rs
@@ -2,6 +2,9 @@ use crate::core::config::siddhi_context::SiddhiContext;
 use crate::core::event::value::AttributeValue;
 use crate::core::extension::TableFactory;
 use crate::core::table::Table;
+use crate::core::table::{CompiledCondition, CompiledUpdateSet, SimpleCompiledCondition, SimpleCompiledUpdateSet};
+use crate::query_api::expression::Expression;
+use crate::query_api::execution::query::output::stream::UpdateSet;
 use std::collections::{HashMap, VecDeque};
 use std::fmt::Debug;
 use std::sync::{Arc, RwLock};
@@ -71,6 +74,14 @@ impl Table for CacheTable {
 
     fn contains(&self, values: &[AttributeValue]) -> bool {
         self.rows.read().unwrap().iter().any(|row| row == values)
+    }
+
+    fn compile_condition(&self, cond: Expression) -> Box<dyn CompiledCondition> {
+        Box::new(SimpleCompiledCondition(cond))
+    }
+
+    fn compile_update_set(&self, us: UpdateSet) -> Box<dyn CompiledUpdateSet> {
+        Box::new(SimpleCompiledUpdateSet(us))
     }
 
     fn clone_table(&self) -> Box<dyn Table> {

--- a/siddhi_rust/src/core/table/jdbc_table.rs
+++ b/siddhi_rust/src/core/table/jdbc_table.rs
@@ -1,6 +1,11 @@
 use crate::core::config::siddhi_context::SiddhiContext;
 use crate::core::event::value::AttributeValue;
-use crate::core::table::Table;
+use crate::core::table::{
+    Table, CompiledCondition, CompiledUpdateSet, SimpleCompiledCondition,
+    SimpleCompiledUpdateSet,
+};
+use crate::query_api::expression::Expression;
+use crate::query_api::execution::query::output::stream::UpdateSet;
 use rusqlite::types::{Value, ValueRef};
 use rusqlite::{params_from_iter, Connection};
 use std::collections::HashMap;
@@ -126,6 +131,14 @@ impl Table for JdbcTable {
 
     fn contains(&self, values: &[AttributeValue]) -> bool {
         self.find(values).is_some()
+    }
+
+    fn compile_condition(&self, cond: Expression) -> Box<dyn CompiledCondition> {
+        Box::new(SimpleCompiledCondition(cond))
+    }
+
+    fn compile_update_set(&self, us: UpdateSet) -> Box<dyn CompiledUpdateSet> {
+        Box::new(SimpleCompiledUpdateSet(us))
     }
 
     fn clone_table(&self) -> Box<dyn Table> {


### PR DESCRIPTION
## Summary
- introduce `CompiledCondition` and `CompiledUpdateSet` marker traits
- let `Table` compile expressions and update sets
- add default implementations so tables do not have to override
- implement explicit compilation methods for `InMemoryTable`, `CacheTable`, and `JdbcTable`

## Testing
- `cargo check`
- `cargo test --no-run`


------
https://chatgpt.com/codex/tasks/task_e_686006b41024832592d6c1f222a82d78