### PR TITLE
Support compiled table operations

### DIFF
--- a/siddhi_rust/src/core/executor/condition/in_expression_executor.rs
+++ b/siddhi_rust/src/core/executor/condition/in_expression_executor.rs
@@ -4,7 +4,7 @@ use crate::core::config::siddhi_app_context::SiddhiAppContext; // For clone_exec
 use crate::core::event::complex_event::ComplexEvent;
 use crate::core::event::value::AttributeValue;
 use crate::core::executor::expression_executor::ExpressionExecutor;
-use crate::core::table::Table;
+use crate::core::table::{InMemoryCompiledCondition, Table};
 use crate::query_api::definition::attribute::Type as ApiAttributeType; // Import Type enum
 use std::sync::Arc; // For SiddhiAppContext in clone_executor
 
@@ -56,7 +56,7 @@ impl ExpressionExecutor for InExpressionExecutor {
             .get_table(&self.table_id);
 
         if let Some(table) = table_opt {
-            let key = vec![value.clone()];
+            let key = InMemoryCompiledCondition { values: vec![value.clone()] };
             let contains = table.contains(&key);
             Some(AttributeValue::Bool(contains))
         } else {

--- a/siddhi_rust/src/core/query/output/delete_table_processor.rs
+++ b/siddhi_rust/src/core/query/output/delete_table_processor.rs
@@ -2,7 +2,7 @@ use crate::core::config::siddhi_app_context::SiddhiAppContext;
 use crate::core::config::siddhi_query_context::SiddhiQueryContext;
 use crate::core::event::complex_event::ComplexEvent;
 use crate::core::query::processor::{CommonProcessorMeta, ProcessingMode, Processor};
-use crate::core::table::Table;
+use crate::core::table::{InMemoryCompiledCondition, Table};
 use std::sync::{Arc, Mutex};
 
 #[derive(Debug)]
@@ -29,7 +29,8 @@ impl Processor for DeleteTableProcessor {
         while let Some(mut event) = chunk {
             let next = event.set_next(None);
             if let Some(data) = event.get_output_data() {
-                self.table.delete(data);
+                let cond = InMemoryCompiledCondition { values: data.to_vec() };
+                self.table.delete(&cond);
             }
             chunk = next;
         }

--- a/siddhi_rust/src/core/query/output/update_table_processor.rs
+++ b/siddhi_rust/src/core/query/output/update_table_processor.rs
@@ -3,7 +3,7 @@ use crate::core::config::siddhi_query_context::SiddhiQueryContext;
 use crate::core::event::complex_event::ComplexEvent;
 use crate::core::event::stream::stream_event::StreamEvent;
 use crate::core::query::processor::{CommonProcessorMeta, ProcessingMode, Processor};
-use crate::core::table::Table;
+use crate::core::table::{InMemoryCompiledCondition, InMemoryCompiledUpdateSet, Table};
 use std::sync::{Arc, Mutex};
 
 #[derive(Debug)]
@@ -32,7 +32,9 @@ impl Processor for UpdateTableProcessor {
             if let Some(se) = event.as_any().downcast_ref::<StreamEvent>() {
                 let old = se.before_window_data.clone();
                 if let Some(new) = se.get_output_data() {
-                    self.table.update(&old, new);
+                    let cond = InMemoryCompiledCondition { values: old };
+                    let us = InMemoryCompiledUpdateSet { values: new.to_vec() };
+                    self.table.update(&cond, &us);
                 }
             }
             chunk = next;

--- a/siddhi_rust/src/core/stream/input/table_input_handler.rs
+++ b/siddhi_rust/src/core/stream/input/table_input_handler.rs
@@ -1,7 +1,9 @@
 use crate::core::config::siddhi_app_context::SiddhiAppContext;
 use crate::core::event::event::Event;
 use crate::core::event::value::AttributeValue;
-use crate::core::table::Table;
+use crate::core::table::{
+    InMemoryCompiledCondition, InMemoryCompiledUpdateSet, Table,
+};
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
@@ -25,10 +27,13 @@ impl TableInputHandler {
     }
 
     pub fn update(&self, old: Vec<AttributeValue>, new: Vec<AttributeValue>) -> bool {
-        self.table.update(&old, &new)
+        let cond = InMemoryCompiledCondition { values: old };
+        let us = InMemoryCompiledUpdateSet { values: new };
+        self.table.update(&cond, &us)
     }
 
     pub fn delete(&self, values: Vec<AttributeValue>) -> bool {
-        self.table.delete(&values)
+        let cond = InMemoryCompiledCondition { values };
+        self.table.delete(&cond)
     }
 }

--- a/siddhi_rust/tests/cache_table.rs
+++ b/siddhi_rust/tests/cache_table.rs
@@ -1,5 +1,7 @@
 use siddhi_rust::core::event::value::AttributeValue;
-use siddhi_rust::core::table::{CacheTable, Table};
+use siddhi_rust::core::table::{
+    CacheTable, InMemoryCompiledCondition, InMemoryCompiledUpdateSet, Table,
+};
 
 #[test]
 fn test_cache_insert_and_eviction() {
@@ -11,9 +13,9 @@ fn test_cache_insert_and_eviction() {
     table.insert(&r2);
     table.insert(&r3);
     // r1 should be evicted
-    assert!(!table.contains(&r1));
-    assert!(table.contains(&r2));
-    assert!(table.contains(&r3));
+    assert!(!table.contains(&InMemoryCompiledCondition { values: r1 }));
+    assert!(table.contains(&InMemoryCompiledCondition { values: r2.clone() }));
+    assert!(table.contains(&InMemoryCompiledCondition { values: r3.clone() }));
 }
 
 #[test]
@@ -22,10 +24,12 @@ fn test_cache_update_delete_find() {
     let r1 = vec![AttributeValue::Int(1)];
     table.insert(&r1);
     let r2 = vec![AttributeValue::Int(2)];
-    assert!(table.update(&r1, &r2));
-    assert!(!table.contains(&r1));
-    assert!(table.contains(&r2));
-    assert_eq!(table.find(&r2), Some(r2.clone()));
-    assert!(table.delete(&r2));
-    assert!(table.find(&r2).is_none());
+    let cond = InMemoryCompiledCondition { values: r1.clone() };
+    let us = InMemoryCompiledUpdateSet { values: r2.clone() };
+    assert!(table.update(&cond, &us));
+    assert!(!table.contains(&InMemoryCompiledCondition { values: r1 }));
+    assert!(table.contains(&InMemoryCompiledCondition { values: r2.clone() }));
+    assert_eq!(table.find(&InMemoryCompiledCondition { values: r2.clone() }), Some(r2.clone()));
+    assert!(table.delete(&InMemoryCompiledCondition { values: r2.clone() }));
+    assert!(table.find(&InMemoryCompiledCondition { values: r2 }).is_none());
 }

--- a/siddhi_rust/tests/in_memory_table.rs
+++ b/siddhi_rust/tests/in_memory_table.rs
@@ -1,5 +1,7 @@
 use siddhi_rust::core::event::value::AttributeValue;
-use siddhi_rust::core::table::{InMemoryTable, Table};
+use siddhi_rust::core::table::{
+    InMemoryCompiledCondition, InMemoryCompiledUpdateSet, InMemoryTable, Table,
+};
 
 #[test]
 fn test_insert_and_contains() {
@@ -9,7 +11,7 @@ fn test_insert_and_contains() {
         AttributeValue::String("a".to_string()),
     ];
     table.insert(&row);
-    assert!(table.contains(&row));
+    assert!(table.contains(&InMemoryCompiledCondition { values: row.clone() }));
 }
 
 #[test]
@@ -18,7 +20,7 @@ fn test_contains_false() {
     let row1 = vec![AttributeValue::Int(2)];
     let row2 = vec![AttributeValue::Int(3)];
     table.insert(&row1);
-    assert!(!table.contains(&row2));
+    assert!(!table.contains(&InMemoryCompiledCondition { values: row2 }));
 }
 
 #[test]
@@ -27,9 +29,11 @@ fn test_update() {
     let old = vec![AttributeValue::Int(1)];
     let new = vec![AttributeValue::Int(2)];
     table.insert(&old);
-    assert!(table.update(&old, &new));
-    assert!(!table.contains(&old));
-    assert!(table.contains(&new));
+    let cond = InMemoryCompiledCondition { values: old.clone() };
+    let us = InMemoryCompiledUpdateSet { values: new.clone() };
+    assert!(table.update(&cond, &us));
+    assert!(!table.contains(&InMemoryCompiledCondition { values: old }));
+    assert!(table.contains(&InMemoryCompiledCondition { values: new }));
 }
 
 #[test]
@@ -39,9 +43,9 @@ fn test_delete() {
     let row2 = vec![AttributeValue::Int(2)];
     table.insert(&row1);
     table.insert(&row2);
-    assert!(table.delete(&row1));
-    assert!(!table.contains(&row1));
-    assert!(table.contains(&row2));
+    assert!(table.delete(&InMemoryCompiledCondition { values: row1.clone() }));
+    assert!(!table.contains(&InMemoryCompiledCondition { values: row1 }));
+    assert!(table.contains(&InMemoryCompiledCondition { values: row2.clone() }));
 }
 
 #[test]
@@ -49,7 +53,9 @@ fn test_find() {
     let table = InMemoryTable::new();
     let row = vec![AttributeValue::Int(42)];
     table.insert(&row);
-    let found = table.find(&row);
+    let found = table.find(&InMemoryCompiledCondition { values: row.clone() });
     assert_eq!(found, Some(row.clone()));
-    assert!(table.find(&[AttributeValue::Int(0)]).is_none());
+    assert!(table
+        .find(&InMemoryCompiledCondition { values: vec![AttributeValue::Int(0)] })
+        .is_none());
 }

--- a/siddhi_rust/tests/jdbc_table.rs
+++ b/siddhi_rust/tests/jdbc_table.rs
@@ -3,7 +3,9 @@ use siddhi_rust::core::config::siddhi_app_context::SiddhiAppContext;
 use siddhi_rust::core::config::siddhi_context::SiddhiContext;
 use siddhi_rust::core::event::value::AttributeValue;
 use siddhi_rust::core::persistence::data_source::{DataSource, DataSourceConfig};
-use siddhi_rust::core::table::{JdbcTable, Table};
+use siddhi_rust::core::table::{
+    InMemoryCompiledCondition, InMemoryCompiledUpdateSet, JdbcTable, Table,
+};
 use std::any::Any;
 use std::sync::{Arc, Mutex};
 
@@ -71,16 +73,18 @@ fn test_jdbc_table_crud() {
         AttributeValue::String("b".into()),
     ];
     table.insert(&row1);
-    assert!(table.contains(&row1));
+    assert!(table.contains(&InMemoryCompiledCondition { values: row1.clone() }));
 
     let row2 = vec![
         AttributeValue::String("x".into()),
         AttributeValue::String("y".into()),
     ];
-    assert!(table.update(&row1, &row2));
-    assert!(!table.contains(&row1));
-    assert!(table.contains(&row2));
+    let cond = InMemoryCompiledCondition { values: row1.clone() };
+    let us = InMemoryCompiledUpdateSet { values: row2.clone() };
+    assert!(table.update(&cond, &us));
+    assert!(!table.contains(&InMemoryCompiledCondition { values: row1 }));
+    assert!(table.contains(&InMemoryCompiledCondition { values: row2.clone() }));
 
-    assert!(table.delete(&row2));
-    assert!(!table.contains(&row2));
+    assert!(table.delete(&InMemoryCompiledCondition { values: row2.clone() }));
+    assert!(!table.contains(&InMemoryCompiledCondition { values: row2 }));
 }

--- a/siddhi_rust/tests/table_ops.rs
+++ b/siddhi_rust/tests/table_ops.rs
@@ -11,7 +11,9 @@ use siddhi_rust::core::query::output::InsertIntoTableProcessor;
 use siddhi_rust::core::query::processor::Processor;
 use siddhi_rust::core::stream::input::table_input_handler::TableInputHandler;
 use siddhi_rust::core::table::JdbcTable;
-use siddhi_rust::core::table::{InMemoryTable, Table};
+use siddhi_rust::core::table::{
+    InMemoryCompiledCondition, InMemoryCompiledUpdateSet, InMemoryTable, Table,
+};
 use std::any::Any;
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -82,7 +84,7 @@ fn test_table_input_handler_add() {
         .get_siddhi_context()
         .get_table("T1")
         .unwrap()
-        .contains(&[AttributeValue::Int(5)]));
+        .contains(&InMemoryCompiledCondition { values: vec![AttributeValue::Int(5)] }));
 }
 
 #[test]
@@ -112,7 +114,7 @@ fn test_insert_into_table_processor() {
         .get_siddhi_context()
         .get_table("T2")
         .unwrap()
-        .contains(&[AttributeValue::Int(7)]));
+        .contains(&InMemoryCompiledCondition { values: vec![AttributeValue::Int(7)] }));
 }
 
 #[test]
@@ -133,20 +135,20 @@ fn test_table_input_handler_update_delete_find() {
         0,
         vec![AttributeValue::String("a".into())],
     )]);
-    assert!(table.contains(&[AttributeValue::String("a".into())]));
+    assert!(table.contains(&InMemoryCompiledCondition { values: vec![AttributeValue::String("a".into())] }));
     assert!(handler.update(
         vec![AttributeValue::String("a".into())],
         vec![AttributeValue::String("b".into())]
     ));
-    assert!(table.contains(&[AttributeValue::String("b".into())]));
+    assert!(table.contains(&InMemoryCompiledCondition { values: vec![AttributeValue::String("b".into())] }));
     assert!(handler.delete(vec![AttributeValue::String("b".into())]));
-    assert!(!table.contains(&[AttributeValue::String("b".into())]));
+    assert!(!table.contains(&InMemoryCompiledCondition { values: vec![AttributeValue::String("b".into())] }));
     handler.add(vec![Event::new_with_data(
         0,
         vec![AttributeValue::String("x".into())],
     )]);
     assert_eq!(
-        table.find(&[AttributeValue::String("x".into())]),
+        table.find(&InMemoryCompiledCondition { values: vec![AttributeValue::String("x".into())] }),
         Some(vec![AttributeValue::String("x".into())])
     );
 }
@@ -181,14 +183,14 @@ fn test_table_input_handler_jdbc() {
         0,
         vec![AttributeValue::String("a".into())],
     )]);
-    assert!(table.contains(&[AttributeValue::String("a".into())]));
+    assert!(table.contains(&InMemoryCompiledCondition { values: vec![AttributeValue::String("a".into())] }));
     assert!(handler.update(
         vec![AttributeValue::String("a".into())],
         vec![AttributeValue::String("b".into())]
     ));
-    assert!(table.contains(&[AttributeValue::String("b".into())]));
+    assert!(table.contains(&InMemoryCompiledCondition { values: vec![AttributeValue::String("b".into())] }));
     assert!(handler.delete(vec![AttributeValue::String("b".into())]));
-    assert!(!table.contains(&[AttributeValue::String("b".into())]));
+    assert!(!table.contains(&InMemoryCompiledCondition { values: vec![AttributeValue::String("b".into())] }));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- introduce `InMemoryCompiledCondition` and `InMemoryCompiledUpdateSet`
- allow tables to operate on compiled conditions and update sets
- add direct update/delete/find helpers in cache table
- compile conditions and update sets into the new in-memory structures

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6860ace1565c8325b0be8bd19dff94cc