### PR TITLE
Enable dynamic extension registration

### DIFF
--- a/siddhi_rust/src/core/extension/mod.rs
+++ b/siddhi_rust/src/core/extension/mod.rs
@@ -149,3 +149,16 @@ impl SinkFactory for LogSinkFactory {
         Box::new(self.clone())
     }
 }
+
+/// FFI callback type used when dynamically loading extensions.
+pub type RegisterFn = unsafe extern "C" fn(&crate::core::siddhi_manager::SiddhiManager);
+
+/// Symbol names looked up by [`SiddhiManager::set_extension`].
+pub const REGISTER_EXTENSION_FN: &[u8] = b"register_extension";
+pub const REGISTER_WINDOWS_FN: &[u8] = b"register_windows";
+pub const REGISTER_FUNCTIONS_FN: &[u8] = b"register_functions";
+pub const REGISTER_SOURCES_FN: &[u8] = b"register_sources";
+pub const REGISTER_SINKS_FN: &[u8] = b"register_sinks";
+pub const REGISTER_STORES_FN: &[u8] = b"register_stores";
+pub const REGISTER_SOURCE_MAPPERS_FN: &[u8] = b"register_source_mappers";
+pub const REGISTER_SINK_MAPPERS_FN: &[u8] = b"register_sink_mappers";

--- a/siddhi_rust/tests/dynamic_ext_integration.rs
+++ b/siddhi_rust/tests/dynamic_ext_integration.rs
@@ -1,11 +1,8 @@
-use std::sync::Arc;
-use siddhi_rust::core::config::{siddhi_app_context::SiddhiAppContext, siddhi_query_context::SiddhiQueryContext};
+#[path = "common/mod.rs"]
+mod common;
+use common::AppRunner;
 use siddhi_rust::core::siddhi_manager::SiddhiManager;
-use siddhi_rust::core::util::parser::{ExpressionParserContext, parse_expression};
-use siddhi_rust::query_api::definition::attribute::Type as AttrType;
-use siddhi_rust::query_api::definition::StreamDefinition;
-use siddhi_rust::query_api::expression::Expression;
-use siddhi_rust::query_api::siddhi_app::SiddhiApp;
+use siddhi_rust::core::event::value::AttributeValue;
 
 #[test]
 fn test_dynamic_extension_loading() {
@@ -13,36 +10,16 @@ fn test_dynamic_extension_loading() {
     let lib_path = custom_dyn_ext::library_path();
     manager.set_extension("dynlib", lib_path.to_str().unwrap().to_string()).unwrap();
 
-    // verify window factory registered
     let ctx = manager.siddhi_context();
     assert!(ctx.get_window_factory("dynWindow").is_some());
-    assert!(ctx.get_attribute_aggregator_factory("dynConstAgg").is_some());
+    assert!(ctx.get_scalar_function_factory("dynPlusOne").is_some());
 
-    // Use custom aggregator via expression parser
-    let app = Arc::new(SiddhiApp::new("app".to_string()));
-    let app_ctx = Arc::new(SiddhiAppContext::new(ctx, "app".to_string(), Arc::clone(&app), String::new()));
-    let q_ctx = Arc::new(SiddhiQueryContext::new(Arc::clone(&app_ctx), "q".to_string(), None));
-    let stream_def = Arc::new(StreamDefinition::new("S".to_string()).attribute("v".to_string(), AttrType::INT));
-    let meta = siddhi_rust::core::event::stream::meta_stream_event::MetaStreamEvent::new_for_single_input(Arc::clone(&stream_def));
-    let mut map = std::collections::HashMap::new();
-    map.insert("S".to_string(), Arc::new(meta));
-    let parse_ctx = ExpressionParserContext {
-        siddhi_app_context: app_ctx,
-        siddhi_query_context: q_ctx,
-        stream_meta_map: map,
-        table_meta_map: std::collections::HashMap::new(),
-        window_meta_map: std::collections::HashMap::new(),
-        aggregation_meta_map: std::collections::HashMap::new(),
-        state_meta_map: std::collections::HashMap::new(),
-        stream_positions: {
-            let mut m = std::collections::HashMap::new();
-            m.insert("S".to_string(), 0);
-            m
-        },
-        default_source: "S".to_string(),
-        query_name: "Q",
-    };
-    let expr = Expression::function_no_ns("dynConstAgg".to_string(), vec![]);
-    let exec = parse_expression(&expr, &parse_ctx).unwrap();
-    assert_eq!(exec.execute(None), Some(siddhi_rust::core::event::value::AttributeValue::Int(7)));
+    let app = "\
+        define stream In (v int);\n\
+        define stream Out (v int);\n\
+        from In#dynWindow() select dynPlusOne(v) as v insert into Out;\n";
+    let runner = AppRunner::new_with_manager(manager, app, "Out");
+    runner.send("In", vec![AttributeValue::Int(1)]);
+    let out = runner.shutdown();
+    assert_eq!(out, vec![vec![AttributeValue::Int(2)]]);
 }


### PR DESCRIPTION
## Summary
- add FFI constants for extension registration symbols
- load all available registration callbacks in `SiddhiManager::set_extension`
- provide example dynamic extension exposing a window and scalar function
- test runtime loading of dynamic extension
- document how to build and load custom dynamic libraries

## Testing
- `cargo test --no-run`
- `cargo test test_dynamic_extension_loading -- --test-threads=1` *(failed: process didn't exit successfully)*

------
https://chatgpt.com/codex/tasks/task_e_6877c99334fc8325842fb15a3023dc30