### PR TITLE
Add missing utilities and metrics enhancements

### DIFF
--- a/siddhi_rust/src/core/util/README.md
+++ b/siddhi_rust/src/core/util/README.md
@@ -20,8 +20,9 @@ placeholders noted below.
 
 ## TODOs
 
-* Many Java utility classes (lock helpers, snapshot utilities,
-  etc.) are still missing.
-* Metrics system is rudimentary and should be extended for production use.
+* Fill out additional helpers from the Java util package as
+  the Rust port grows.
+* Metrics system remains basic and should be extended for
+  production use.
 
 Contributions welcome!

--- a/siddhi_rust/src/core/util/lock.rs
+++ b/siddhi_rust/src/core/util/lock.rs
@@ -1,0 +1,100 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+/// Simple wrapper around a `Mutex` identified by an id.
+#[derive(Debug, Clone)]
+pub struct LockWrapper {
+    lock_id: String,
+    lock: Arc<Mutex<()>>, // always initialized
+}
+
+impl LockWrapper {
+    /// Create a new lock wrapper with the given id.
+    pub fn new(lock_id: &str) -> Self {
+        Self {
+            lock_id: lock_id.to_string(),
+            lock: Arc::new(Mutex::new(())),
+        }
+    }
+
+    /// Acquire the underlying lock.
+    pub fn lock(&self) -> std::sync::MutexGuard<'_, ()> {
+        self.lock.lock().unwrap()
+    }
+
+    /// Replace the internal lock with another `Arc`.
+    pub fn set_lock(&mut self, lock: Arc<Mutex<()>>) {
+        self.lock = lock;
+    }
+
+    /// Get the current lock `Arc`.
+    pub fn get_lock(&self) -> Arc<Mutex<()>> {
+        Arc::clone(&self.lock)
+    }
+}
+
+impl PartialEq for LockWrapper {
+    fn eq(&self, other: &Self) -> bool {
+        self.lock_id == other.lock_id
+    }
+}
+impl Eq for LockWrapper {}
+
+/// Synchronizes two or more `LockWrapper`s so that they share the same mutex.
+#[derive(Debug, Default)]
+pub struct LockSynchronizer {
+    holder_map: HashMap<String, Vec<Arc<Mutex<LockWrapper>>>>,
+}
+
+impl LockSynchronizer {
+    pub fn new() -> Self {
+        Self {
+            holder_map: HashMap::new(),
+        }
+    }
+
+    /// Ensure both wrappers share the same lock and update any previously
+    /// synchronized wrappers as well.
+    pub fn sync(&mut self, one: Arc<Mutex<LockWrapper>>, two: Arc<Mutex<LockWrapper>>) {
+        let id1 = one.lock().unwrap().lock_id.clone();
+        let id2 = two.lock().unwrap().lock_id.clone();
+        let one_exists = self.holder_map.contains_key(&id1);
+        let two_exists = self.holder_map.contains_key(&id2);
+
+        if !one_exists && !two_exists {
+            let new_lock = Arc::new(Mutex::new(()));
+            one.lock().unwrap().set_lock(new_lock.clone());
+            two.lock().unwrap().set_lock(new_lock.clone());
+            self.holder_map.insert(id1.clone(), vec![Arc::clone(&two)]);
+            self.holder_map.insert(id2.clone(), vec![Arc::clone(&one)]);
+        } else if one_exists && !two_exists {
+            let lock = one.lock().unwrap().get_lock();
+            two.lock().unwrap().set_lock(lock.clone());
+            self.holder_map
+                .entry(id1.clone())
+                .or_default()
+                .push(Arc::clone(&two));
+            self.holder_map.insert(id2.clone(), vec![Arc::clone(&one)]);
+        } else if !one_exists && two_exists {
+            let lock = two.lock().unwrap().get_lock();
+            one.lock().unwrap().set_lock(lock.clone());
+            self.holder_map
+                .entry(id2.clone())
+                .or_default()
+                .push(Arc::clone(&one));
+            self.holder_map.insert(id1.clone(), vec![Arc::clone(&two)]);
+        } else {
+            let lock = one.lock().unwrap().get_lock();
+            two.lock().unwrap().set_lock(lock.clone());
+            if let Some(list) = self.holder_map.get(&id2) {
+                for holder in list {
+                    holder.lock().unwrap().set_lock(lock.clone());
+                }
+            }
+            self.holder_map
+                .entry(id1.clone())
+                .or_default()
+                .push(Arc::clone(&two));
+        }
+    }
+}

--- a/siddhi_rust/src/core/util/metrics.rs
+++ b/siddhi_rust/src/core/util/metrics.rs
@@ -1,11 +1,19 @@
-use crate::core::config::SiddhiAppContext;
+use crate::core::config::{SiddhiAppContext, SiddhiContext};
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
-use std::sync::{atomic::{AtomicI64, AtomicU64, Ordering}, Arc, Mutex};
+use std::sync::{
+    atomic::{AtomicI64, AtomicU64, Ordering},
+    Arc, Mutex,
+};
 use std::time::Duration;
 
-static LATENCY_BY_STREAM: Lazy<Mutex<HashMap<String, Arc<LatencyTracker>>>> = Lazy::new(|| Mutex::new(HashMap::new()));
-static THROUGHPUT_BY_STREAM: Lazy<Mutex<HashMap<String, Arc<ThroughputTracker>>>> = Lazy::new(|| Mutex::new(HashMap::new()));
+static LATENCY_BY_STREAM: Lazy<Mutex<HashMap<String, Arc<LatencyTracker>>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
+static THROUGHPUT_BY_STREAM: Lazy<Mutex<HashMap<String, Arc<ThroughputTracker>>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
+static COUNTERS: Lazy<Mutex<HashMap<String, Arc<Counter>>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
+static TIMERS: Lazy<Mutex<HashMap<String, Arc<Timer>>>> = Lazy::new(|| Mutex::new(HashMap::new()));
 
 #[derive(Debug, Default)]
 pub struct LatencyTracker {
@@ -82,6 +90,66 @@ impl ThroughputTracker {
 #[derive(Debug, Default)]
 pub struct BufferedEventsTracker {
     count: AtomicI64,
+}
+
+#[derive(Debug, Default)]
+pub struct Counter {
+    count: AtomicU64,
+}
+
+impl Counter {
+    pub fn new(name: &str, _ctx: &SiddhiContext) -> Arc<Self> {
+        let c = Arc::new(Self::default());
+        COUNTERS
+            .lock()
+            .unwrap()
+            .insert(name.to_string(), Arc::clone(&c));
+        c
+    }
+
+    pub fn inc(&self) {
+        self.count.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn add(&self, v: u64) {
+        self.count.fetch_add(v, Ordering::Relaxed);
+    }
+
+    pub fn value(&self) -> u64 {
+        self.count.load(Ordering::Relaxed)
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct Timer {
+    total_ns: AtomicU64,
+    count: AtomicU64,
+}
+
+impl Timer {
+    pub fn new(name: &str, _ctx: &SiddhiContext) -> Arc<Self> {
+        let t = Arc::new(Self::default());
+        TIMERS
+            .lock()
+            .unwrap()
+            .insert(name.to_string(), Arc::clone(&t));
+        t
+    }
+
+    pub fn record(&self, dur: Duration) {
+        self.total_ns
+            .fetch_add(dur.as_nanos() as u64, Ordering::Relaxed);
+        self.count.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn average_ns(&self) -> Option<u64> {
+        let c = self.count.load(Ordering::Relaxed);
+        if c == 0 {
+            None
+        } else {
+            Some(self.total_ns.load(Ordering::Relaxed) / c)
+        }
+    }
 }
 
 impl Clone for BufferedEventsTracker {

--- a/siddhi_rust/src/core/util/mod.rs
+++ b/siddhi_rust/src/core/util/mod.rs
@@ -19,22 +19,25 @@ pub mod thread_barrier;
 // pub mod error;  // This might conflict with core::exception or query_api::error
 // pub mod event;  // This might conflict with core::event
 // pub mod extension;
-// pub mod lock;
+pub mod lock;
 // pub mod persistence;
-// pub mod snapshot;
-// pub mod statistics; // This might conflict with core::config::StatisticsConfiguration
-// pub mod timestamp;
-// pub mod transport;
+pub mod snapshot;
+pub mod statistics; // This might conflict with core::config::StatisticsConfiguration
+                    // pub mod timestamp;
+                    // pub mod transport;
 
 pub use self::attribute_converter::{get_property_value, get_property_value_from_str};
 pub use self::event_serde::{event_from_bytes, event_to_bytes};
 pub use self::executor_service::{ExecutorService, ExecutorServiceRegistry};
 pub use self::id_generator::IdGenerator;
+pub use self::lock::{LockSynchronizer, LockWrapper};
 pub use self::metrics::*;
 pub use self::parser::{parse_expression, ExpressionParserContext}; // Re-export key items from parser
 pub use self::scheduled_executor_service::ScheduledExecutorService;
 pub use self::scheduler::{Schedulable, Scheduler};
 pub use self::serialization::{from_bytes, to_bytes};
 pub use self::siddhi_constants::SiddhiConstants; // Re-export SiddhiConstants
-pub use self::thread_barrier::ThreadBarrier;
+pub use self::snapshot::{IncrementalSnapshot, PersistenceReference};
 pub use self::state_holder::StateHolder;
+pub use self::statistics::{DefaultStatisticsManager, StatisticsManager};
+pub use self::thread_barrier::ThreadBarrier;

--- a/siddhi_rust/src/core/util/snapshot.rs
+++ b/siddhi_rust/src/core/util/snapshot.rs
@@ -1,0 +1,37 @@
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+/// Thread local flag used to request a full snapshot.
+thread_local! {
+    static REQUEST_FULL: RefCell<bool> = RefCell::new(false);
+}
+
+/// Enable or disable full snapshot for the current thread.
+pub fn request_for_full_snapshot(enable: bool) {
+    REQUEST_FULL.with(|f| *f.borrow_mut() = enable);
+}
+
+/// Whether the current thread requested a full snapshot.
+pub fn is_request_for_full_snapshot() -> bool {
+    REQUEST_FULL.with(|f| *f.borrow())
+}
+
+/// Serialized incremental snapshot information placeholder.
+#[derive(Debug, Default, Clone)]
+pub struct IncrementalSnapshot {
+    pub incremental_state: HashMap<String, HashMap<String, Vec<u8>>>,
+    pub incremental_state_base: HashMap<String, HashMap<String, Vec<u8>>>,
+    pub periodic_state: HashMap<String, HashMap<String, Vec<u8>>>,
+}
+
+/// Reference to persistence futures returned when persisting snapshots.
+#[derive(Debug, Clone)]
+pub struct PersistenceReference {
+    pub revision: String,
+}
+
+impl PersistenceReference {
+    pub fn new(revision: String) -> Self {
+        Self { revision }
+    }
+}

--- a/siddhi_rust/src/core/util/statistics.rs
+++ b/siddhi_rust/src/core/util/statistics.rs
@@ -1,0 +1,36 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// Basic trait matching the Java `StatisticsManager` interface.
+pub trait StatisticsManager: Send + Sync {
+    fn start_reporting(&self);
+    fn stop_reporting(&self);
+    fn cleanup(&self);
+}
+
+/// Simple in-memory statistics manager used for tests.
+#[derive(Debug, Default)]
+pub struct DefaultStatisticsManager {
+    running: AtomicBool,
+}
+
+impl DefaultStatisticsManager {
+    pub fn new() -> Self {
+        Self {
+            running: AtomicBool::new(false),
+        }
+    }
+}
+
+impl StatisticsManager for DefaultStatisticsManager {
+    fn start_reporting(&self) {
+        self.running.store(true, Ordering::Relaxed);
+    }
+
+    fn stop_reporting(&self) {
+        self.running.store(false, Ordering::Relaxed);
+    }
+
+    fn cleanup(&self) {
+        self.running.store(false, Ordering::Relaxed);
+    }
+}

--- a/siddhi_rust/tests/stream_junction_stress.rs
+++ b/siddhi_rust/tests/stream_junction_stress.rs
@@ -132,7 +132,8 @@ fn stress_async_concurrent_publish() {
     for h in handles {
         h.join().unwrap();
     }
-    thread::sleep(Duration::from_millis(1000));
+    // Give the async executor sufficient time to process all events.
+    thread::sleep(Duration::from_millis(2000));
     let data = rec.lock().unwrap();
     assert_eq!(data.len(), 2000);
     // metrics


### PR DESCRIPTION
## Summary
- implement lock helpers (`LockWrapper`, `LockSynchronizer`)
- add snapshot helpers and a simple statistics manager
- extend metrics with counters and timers
- expose the new utilities via `util::mod`
- stabilize the async stream junction test

## Testing
- `cargo test --test stream_junction_stress -- --nocapture`
- `cargo test --no-fail-fast -- --show-output`

------
https://chatgpt.com/codex/tasks/task_e_687f042d720c8325babb3950a3b125fc