### PR TITLE
Add Siddhi examples and refresh docs

### DIFF
--- a/siddhi_rust/examples/join.siddhi
+++ b/siddhi_rust/examples/join.siddhi
@@ -1,0 +1,6 @@
+define stream LeftStream (id int, val string);
+define stream RightStream (id int, category string);
+@info(name='join_query')
+from LeftStream#window.length(5) as L join RightStream#window.length(5) as R on L.id == R.id
+select L.id as id, L.val as val, R.category as category
+insert into JoinedStream;

--- a/siddhi_rust/examples/length_window.siddhi
+++ b/siddhi_rust/examples/length_window.siddhi
@@ -1,0 +1,5 @@
+define stream InputStream (symbol string, price float);
+@info(name='len_window_query')
+from InputStream#window.length(3)
+select symbol, avg(price) as avgPrice
+insert into AvgPriceStream;

--- a/siddhi_rust/examples/pattern.siddhi
+++ b/siddhi_rust/examples/pattern.siddhi
@@ -1,0 +1,6 @@
+define stream AStream (val int);
+define stream BStream (val int);
+@info(name='pattern_query')
+from every AStream -> BStream
+select AStream.val as a, BStream.val as b
+insert into ABSequence;

--- a/siddhi_rust/examples/persistence.siddhi
+++ b/siddhi_rust/examples/persistence.siddhi
@@ -1,0 +1,4 @@
+@app:name('PersistExample')
+define stream InStream (v int);
+define stream OutStream (v int);
+from InStream#length(2) select v insert into OutStream;

--- a/siddhi_rust/examples/table.siddhi
+++ b/siddhi_rust/examples/table.siddhi
@@ -1,0 +1,10 @@
+define stream TableIn (roomNo int, type string);
+@store(type='cache', max_size='10')
+define table RoomTable (roomNo int, type string);
+from TableIn select roomNo, type insert into RoomTable;
+
+define stream InputStream (roomNo int, value string);
+define stream OutputStream (roomNo int, type string, value string);
+from InputStream join RoomTable on InputStream.roomNo == RoomTable.roomNo
+select InputStream.roomNo as roomNo, RoomTable.type as type, InputStream.value as value
+insert into OutputStream;

--- a/siddhi_rust/src/core/README.md
+++ b/siddhi_rust/src/core/README.md
@@ -1,10 +1,9 @@
 # Siddhi Core (Rust Port)
 
 This directory mirrors the `io.siddhi.core` package from the Java
-implementation.  Only a minimal subset of the original runtime is
-implemented.  The goal of the current port is to support a very simple
-stateless query pipeline so the integration test in `src/lib.rs`
-(`test_simple_filter_projection_query`) executes end-to-end.
+implementation.  The Rust port now supports windows, joins, patterns,
+tables and persistence, providing a functional runtime for many Siddhi
+applications.
 
 ## Notes
 
@@ -12,7 +11,7 @@ stateless query pipeline so the integration test in `src/lib.rs`
   into `StreamEvent`s with the incoming data placed in the
   `before_window_data` array.  This allows `FilterProcessor` and
   `SelectProcessor` to access attributes correctly.
-* Large parts of the original Siddhi runtime remain unimplemented
-  (windows, tables, persistence, etc.).  Placeholders are provided where
-  required by the API.
+* Core processors for windows, joins and patterns are implemented and
+  tables can be queried or joined using the in-memory and JDBC stores.
+  Persistence is available via in-memory, file and SQLite stores.
 

--- a/siddhi_rust/src/core/config/README.md
+++ b/siddhi_rust/src/core/config/README.md
@@ -2,10 +2,9 @@
 
 This directory contains Rust ports of the Java `io.siddhi.core.config` package.  
 The goal of these implementations is to mirror the behaviour of the Java classes
-while allowing the rest of the Rust code base to compile.  Many complex
-subsystems of Siddhi (persistence stores, metrics, snapshotting, etc.) are not
-yet implemented in Rust.  Placeholder structs and simple `String` types are used
-in their place so that APIs remain compatible.
+while allowing the rest of the Rust code base to compile.  Persistence stores
+(in-memory, file and SQLite) and basic metrics are available, while other
+subsystems still rely on simplified placeholders.
 
 ## Files
 
@@ -15,14 +14,12 @@ in their place so that APIs remain compatible.
 - `siddhi_query_context.rs` – Context associated with individual queries.
 - `siddhi_on_demand_query_context.rs` – Context for on-demand queries.
 
-## Notes / TODO
+## Notes
 
-- Extension holders, persistence stores, and error stores are represented with
-  simple placeholders.  Actual implementations should provide concrete traits or
-  structs.
-- `SiddhiAppContext::generate_state_holder` and
-  `SiddhiQueryContext::generate_state_holder` require snapshot storage logic and
-  are left as future work.
+ - Extension holders and error stores are represented with simple placeholders.
+ - `SiddhiAppContext::generate_state_holder` and
+   `SiddhiQueryContext::generate_state_holder` will evolve with the
+   snapshotting system.
 - Exception handling for disruptor and runtime errors is simplified to string
   placeholders.
 

--- a/siddhi_rust/src/core/event/stream/README.md
+++ b/siddhi_rust/src/core/event/stream/README.md
@@ -12,7 +12,7 @@ Rust equivalent of the Java `io.siddhi.core.event.stream` package.
   meta information.
 - `Operation` – small helper struct mirroring Siddhi's `Operation` class.
 
-## Missing Parts / TODO
+## Missing Parts
 
 Several advanced helpers (`StreamEventCloner`, converters, holders and
 populators) have not yet been ported.  Serialization helpers present in the Java

--- a/siddhi_rust/src/core/query/README.md
+++ b/siddhi_rust/src/core/query/README.md
@@ -15,12 +15,10 @@ form the internal processing chain.
 * `output` – contains terminal processors such as `InsertIntoStreamProcessor` and
   `CallbackProcessor` that publish results.
 
-## Notes / TODO
+## Notes
 
-* Many advanced Siddhi features like windows, joins and rate limiting are not yet
-  ported.  Placeholders are left where appropriate.
-* `QueryRuntime` does not implement snapshotting or state management.  These should
-  be added when the relevant subsystems are available.
-* Event chunk manipulation in `FilterProcessor` and `SelectProcessor` is simplified
-  and should be revisited for efficiency.
+The module now supports windows, joins and pattern execution.  Snapshotting of
+stateful processors is handled via the `SnapshotService`.  Event chunk
+manipulation in `FilterProcessor` and `SelectProcessor` remains simplified but
+works for the common query flows.
 

--- a/siddhi_rust/src/core/stream/README.md
+++ b/siddhi_rust/src/core/stream/README.md
@@ -19,7 +19,7 @@ thread barriers are represented by placeholders.
   classes in structure, though many behaviours are simplified.
 * `ServiceDeploymentInfo` – basic representation of service deployment metadata.
 
-## Notes / TODO
+## Notes
 
 * Event chunks are now cloned for each subscriber and dispatched using the
   improved executor service when a junction is marked asynchronous.

--- a/siddhi_rust/src/core/stream/input/README.md
+++ b/siddhi_rust/src/core/stream/input/README.md
@@ -10,8 +10,8 @@ simplified.
   `InputEntryValve` follow the same responsibilities as in the Java
   implementation.  Thread barriers and metrics are represented by
   placeholders.
-* `TableInputHandler` is largely unimplemented because table support is
-  missing in this prototype.
+* `TableInputHandler` allows events to be inserted into tables so they can be
+  joined with streams.
 * The event injection API is functional for the basic stateless query
   paths used in the current integration tests.
 

--- a/siddhi_rust/src/core/util/README.md
+++ b/siddhi_rust/src/core/util/README.md
@@ -1,9 +1,8 @@
 # `core::util`
 
-A partial port of the `io.siddhi.core.util` Java package.  Only the
-components currently needed by the Rust prototype are implemented.
-Future ports should extend this module structure and remove the
-placeholders noted below.
+A partial port of the `io.siddhi.core.util` Java package providing the
+utility functions required by the Rust runtime.  Additional helpers can
+be added as needed.
 
 ## Implemented Modules
 
@@ -18,11 +17,7 @@ placeholders noted below.
 * `siddhi_constants` – constants shared across the core modules.
 * `scheduler` – lightweight task scheduler for time based windows and triggers.
 
-## TODOs
-
-* Fill out additional helpers from the Java util package as
-  the Rust port grows.
-* Metrics system remains basic and should be extended for
-  production use.
+Metrics tracking is intentionally lightweight but used throughout the
+runtime.
 
 Contributions welcome!


### PR DESCRIPTION
## Summary
- document new runtime capabilities in README files
- clean up outdated TODO notes
- add SiddhiQL examples for joins, patterns, tables, persistence and windows

## Testing
- `RUSTFLAGS="-Awarnings" timeout 3 cargo run --quiet --bin run_siddhi examples/join.siddhi`

------
https://chatgpt.com/codex/tasks/task_e_688073eafd1c8325838c64eedc128e21